### PR TITLE
Implement Itertools.merge(other).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub use adaptors::{
     Batching,
     GroupBy,
     Step,
+    Merge,
 };
 pub use intersperse::Intersperse;
 pub use islice::{ISlice};
@@ -465,6 +466,16 @@ pub trait Itertools : Iterator {
         Self: Sized,
     {
         self.collect()
+    }
+
+    /// Given two sorted iterators (this and `other`), return an iterator adapter yeilds elements
+    /// from both iterators in sorted order.
+    fn merge<B>(self, other: B) -> Merge<Self::Item, Self, B> where
+        Self: Sized,
+        B: Iterator<Item = Self::Item>,
+        Self::Item: PartialOrd,
+    {
+        Merge::new(self, other)
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -322,3 +322,8 @@ fn trait_pointers() {
     //assert_eq!(it.dropn(2), 2);
     */
 }
+
+#[test]
+fn merge() {
+    assert_iters_equal((0..10).step(2).merge((1..10).step(2)), (0..10));
+}


### PR DESCRIPTION
`Itertools.merge` merges two sorted iterators (with items implementing Ord) into a single sorted iterator.