### PR TITLE
Add an iterator adapter that allows peeking of multiple values

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -578,6 +578,7 @@ impl<K, I: Iterator> Iterator for EnumerateFrom<I, K> where
     }
 }
 
+/// An Iterator adaptor that allows the user to peek at multiple *.next()* values without advancing itself.
 pub struct MultiPeek<I: Iterator> {
     iter: Fuse<I>,
     buf: Vec<I::Item>,
@@ -585,10 +586,13 @@ pub struct MultiPeek<I: Iterator> {
 }
 
 impl<I: Iterator> MultiPeek<I> {
+    /// Create a **MultiPeek** iterator.
     pub fn new(iter: I) -> MultiPeek<I> {
         MultiPeek{ iter: iter.fuse(), buf: Vec::new(), index: 0 }
     }
 
+    /// Works exactly like *.next()* with the only difference that it doesn't advance itself.
+    /// *.peek()* kann be called multiple times, behaving exactly like *.next()*.
     pub fn peek(&mut self) -> Option<&<I as Iterator>::Item> {
         let ret = if self.index < self.buf.len() {
             Some(&self.buf[self.index])

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -579,14 +579,14 @@ impl<K, I: Iterator> Iterator for EnumerateFrom<I, K> where
 }
 
 pub struct MultiPeek<I: Iterator> {
-    iter: I,
+    iter: Fuse<I>,
     buf: Vec<I::Item>,
     index: usize,
 }
 
 impl<I: Iterator> MultiPeek<I> {
     pub fn new(iter: I) -> MultiPeek<I> {
-        MultiPeek{ iter: iter, buf: Vec::new(), index: 0 }
+        MultiPeek{ iter: iter.fuse(), buf: Vec::new(), index: 0 }
     }
 
     pub fn peek(&mut self) -> Option<&<I as Iterator>::Item> {
@@ -598,7 +598,7 @@ impl<I: Iterator> MultiPeek<I> {
                     self.buf.push(x);
                     Some(&self.buf[self.index])
                 }
-                None => None
+                None => return None
             }
         };
 

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -625,3 +625,13 @@ impl<I: Iterator> Iterator for MultiPeek<I> {
 
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
+
+impl<I: Iterator> Clone for MultiPeek<I> where
+    I: Clone,
+    I::Item: Clone
+{
+    fn clone(&self) -> Self
+    {
+        clone_fields!(MultiPeek, self, iter, buf, index)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub use adaptors::{
     Step,
     Merge,
     EnumerateFrom,
+    MultiPeek,
 };
 pub use intersperse::Intersperse;
 pub use islice::{ISlice};
@@ -630,6 +631,12 @@ pub trait Itertools : Iterator {
         Self::Item: ToString,
     {
         self.map(|elt| elt.to_string()).join(sep)
+    }
+
+    fn multipeek(self) -> MultiPeek<Self> where
+        Self: Sized
+    {
+        MultiPeek::new(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,6 +633,23 @@ pub trait Itertools : Iterator {
         self.map(|elt| elt.to_string()).join(sep)
     }
 
+    /// Returns an iterator adapter that allows peeking multiple values.
+    ///
+    /// After a call to *.next()* the peeking cursor gets resetted.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let nums = vec![1u8,2,3,4,5];
+    /// let mut peekable = nums.into_iter().multipeek();
+    /// assert_eq!(peekable.peek(), Some(&1));
+    /// assert_eq!(peekable.peek(), Some(&2));
+    /// assert_eq!(peekable.peek(), Some(&3));
+    /// assert_eq!(peekable.next(), Some(1));
+    /// assert_eq!(peekable.peek(), Some(&2));
+    /// ```
     fn multipeek(self) -> MultiPeek<Self> where
         Self: Sized
     {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,7 +13,6 @@ extern crate test;
 
 use std::fmt::Debug;
 use std::iter::order;
-use std::iter::IntoIterator;
 use itertools::Itertools;
 use itertools::Interleave;
 use itertools::Zip;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,6 +13,7 @@ extern crate test;
 
 use std::fmt::Debug;
 use std::iter::order;
+use std::iter::IntoIterator;
 use itertools::Itertools;
 use itertools::Interleave;
 use itertools::Zip;
@@ -333,4 +334,29 @@ fn to_string_join() {
     assert_eq!(many.iter().to_string_join(", "), "1, 2, 3");
     assert_eq!( one.iter().to_string_join(", "), "1");
     assert_eq!(none.iter().to_string_join(", "), "");
+}
+
+#[test]
+fn multipeek() {
+    let nums = vec![1u8,2,3,4,5];
+
+    let multipeek = nums.iter().map(|&x| x).multipeek();
+    assert_eq!(nums, multipeek.collect());
+
+    let mut multipeek = nums.iter().map(|&x| x).multipeek();
+    assert_eq!(multipeek.peek(), Some(&1));
+    assert_eq!(multipeek.next(), Some(1));
+    assert_eq!(multipeek.peek(), Some(&2));
+    assert_eq!(multipeek.peek(), Some(&3));
+    assert_eq!(multipeek.next(), Some(2));
+    assert_eq!(multipeek.peek(), Some(&3));
+    assert_eq!(multipeek.peek(), Some(&4));
+    assert_eq!(multipeek.peek(), Some(&5));
+    assert_eq!(multipeek.peek(), None);
+    assert_eq!(multipeek.next(), Some(3));
+    assert_eq!(multipeek.next(), Some(4));
+    assert_eq!(multipeek.next(), Some(5));
+    assert_eq!(multipeek.next(), None);
+    assert_eq!(multipeek.peek(), None);
+
 }


### PR DESCRIPTION
I find this quite useful, as the ```.peekable()``` adapter from ```std``` is often not enough (it can only peek one element).

The name is far from perfect, I can rename the whole thing if you come up with something better! ;)