### PR TITLE
Take advantage of new where clause feature.

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -39,8 +39,9 @@ impl<I, J> Interleave<I, J> {
     }
 }
 
-impl<I: Iterator, J> Iterator for Interleave<I, J> where
-    J: Iterator<Item=I::Item>
+impl<I, J> Iterator for Interleave<I, J> where
+    I: Iterator,
+    J: Iterator<Item=I::Item>,
 {
     type Item = I::Item;
     #[inline]
@@ -66,13 +67,15 @@ impl<I: Iterator, J> Iterator for Interleave<I, J> where
 /// Created with `.fn_map(..)` on an iterator
 ///
 /// Iterator element type is `B`
-pub struct FnMap<B, I: Iterator>
+pub struct FnMap<B, I> where
+    I: Iterator,
 {
     map: fn(I::Item) -> B,
     iter: I,
 }
 
-impl<B, I: Iterator> FnMap<B, I>
+impl<B, I> FnMap<B, I> where
+    I: Iterator
 {
     pub fn new(iter: I, map: fn(I::Item) -> B) -> Self
     {
@@ -80,7 +83,8 @@ impl<B, I: Iterator> FnMap<B, I>
     }
 }
 
-impl<B, I: Iterator> Iterator for FnMap<B, I>
+impl<B, I> Iterator for FnMap<B, I> where
+    I: Iterator,
 {
     type Item = B;
     #[inline]
@@ -116,13 +120,15 @@ impl<B, I> Clone for FnMap<B, I> where
 /// item to the front of the iterator.
 ///
 /// Iterator element type is **I::Item**.
-pub struct PutBack<I: Iterator>
+pub struct PutBack<I> where
+    I: Iterator,
 {
     top: Option<I::Item>,
     iter: I
 }
 
-impl<I: Iterator> PutBack<I>
+impl<I> PutBack<I>
+    where I: Iterator,
 {
     /// Iterator element type is `A`
     #[inline]
@@ -141,7 +147,8 @@ impl<I: Iterator> PutBack<I>
     }
 }
 
-impl<I: Iterator> Iterator for PutBack<I>
+impl<I> Iterator for PutBack<I> where
+    I: Iterator,
 {
     type Item = I::Item;
     #[inline]
@@ -161,8 +168,8 @@ impl<I: Iterator> Iterator for PutBack<I>
     }
 }
 
-impl<I: Iterator> Clone for PutBack<I> where
-    I: Clone,
+impl<I> Clone for PutBack<I> where
+    I: Iterator + Clone,
     I::Item: Clone
 {
     fn clone(&self) -> Self
@@ -176,14 +183,18 @@ impl<I: Iterator> Clone for PutBack<I> where
 /// the element sets of two iterators **I** and **J**.
 ///
 /// Iterator element type is **(I::Item, J::Item)**.
-pub struct Product<I: Iterator, J> {
+pub struct Product<I, J> where
+    I: Iterator,
+{
     a: I,
     a_cur: Option<I::Item>,
     b: J,
     b_orig: J,
 }
 
-impl<I: Iterator + Clone, J: Clone> Clone for Product<I, J> where
+impl<I, J> Clone for Product<I, J> where
+    I: Iterator + Clone,
+    J: Clone,
     I::Item: Clone,
 {
     fn clone(&self) -> Self
@@ -192,7 +203,9 @@ impl<I: Iterator + Clone, J: Clone> Clone for Product<I, J> where
     }
 }
 
-impl<I: Iterator, J: Clone + Iterator> Product<I, J> where
+impl<I, J> Product<I, J> where
+    I: Iterator,
+    J: Clone + Iterator,
     I::Item: Clone,
 {
     /// Create a new cartesian product iterator
@@ -206,7 +219,9 @@ impl<I: Iterator, J: Clone + Iterator> Product<I, J> where
 }
 
 
-impl<I: Iterator, J: Clone + Iterator> Iterator for Product<I, J> where
+impl<I, J> Iterator for Product<I, J> where
+    I: Iterator,
+    J: Clone + Iterator,
     I::Item: Clone,
 {
     type Item = (I::Item, J::Item);
@@ -253,13 +268,15 @@ impl<I: Iterator, J: Clone + Iterator> Iterator for Product<I, J> where
 /// If the iterator is sorted, all elements will be unique.
 ///
 /// Iterator element type is **I::Item**.
-pub struct Dedup<I: Iterator>
+pub struct Dedup<I> where
+    I: Iterator,
 {
     last: Option<I::Item>,
     iter: I,
 }
 
-impl<I: Iterator + Clone> Clone for Dedup<I> where
+impl<I> Clone for Dedup<I> where
+    I: Iterator + Clone,
     I::Item: Clone,
 {
     fn clone(&self) -> Self
@@ -280,7 +297,8 @@ impl<I> Dedup<I> where I: Iterator
     }
 }
 
-impl<I: Iterator> Iterator for Dedup<I> where
+impl<I> Iterator for Dedup<I> where
+    I: Iterator,
     I::Item: PartialEq
 {
     type Item = I::Item;
@@ -359,14 +377,19 @@ impl<B, F, I> Iterator for Batching<I, F> where
 /// are returned as the iterator elements of `GroupBy`.
 ///
 /// Iterator element type is **(K, Vec\<A\>)**
-pub struct GroupBy<K, I: Iterator, F> {
+pub struct GroupBy<K, I, F> where
+    I: Iterator,
+{
     key: F,
     iter: I,
     current_key: Option<K>,
     elts: Vec<I::Item>,
 }
 
-impl<K: Clone, I: Clone  + Iterator, F: Clone> Clone for GroupBy<K, I, F> where
+impl<K, I, F> Clone for GroupBy<K, I, F> where
+    K: Clone,
+    F: Clone,
+    I: Clone + Iterator,
     I::Item: Clone,
 {
     fn clone(&self) -> Self
@@ -385,8 +408,10 @@ impl<K, F, I> GroupBy<K, I, F> where
     }
 }
 
-impl<K: PartialEq, I: Iterator, F: FnMut(&I::Item) -> K>
-    Iterator for GroupBy<K, I, F>
+impl<K, I, F> Iterator for GroupBy<K, I, F> where
+    K: PartialEq,
+    I: Iterator,
+    F: FnMut(&I::Item) -> K,
 {
     type Item = (K, Vec<I::Item>);
     fn next(&mut self) -> Option<(K, Vec<I::Item>)>
@@ -453,9 +478,9 @@ impl<I> Step<I>
 impl<I> Iterator for Step<I>
     where I: Iterator
 {
-    type Item = <I as Iterator>::Item;
+    type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<<I as Iterator>::Item>
+    fn next(&mut self) -> Option<I::Item>
     {
         let elt = self.iter.next();
         self.iter.dropn(self.skip);
@@ -480,14 +505,16 @@ impl<I> Iterator for Step<I>
 /// If both base iterators are sorted (ascending), the result is sorted.
 ///
 /// Iterator element type is **I::Item**.
-pub struct Merge<I: Iterator, J> where
+pub struct Merge<I, J> where
+    I: Iterator,
     J: Iterator<Item=I::Item>,
 {
     a: Peekable<I>,
     b: Peekable<J>,
 }
 
-impl<I: Iterator, J> Clone for Merge<I, J> where
+impl<I, J> Clone for Merge<I, J> where
+    I: Iterator,
     J: Iterator<Item=I::Item>,
     Peekable<I>: Clone,
     Peekable<J>: Clone,
@@ -498,7 +525,8 @@ impl<I: Iterator, J> Clone for Merge<I, J> where
     }
 }
 
-impl<I: Iterator, J> Merge<I, J> where
+impl<I, J> Merge<I, J> where
+    I: Iterator,
     J: Iterator<Item=I::Item>,
 {
     /// Create a **Merge** iterator.
@@ -511,7 +539,8 @@ impl<I: Iterator, J> Merge<I, J> where
     }
 }
 
-impl<I: Iterator, J> Iterator for Merge<I, J> where
+impl<I, J> Iterator for Merge<I, J> where
+    I: Iterator,
     I::Item: PartialOrd,
     J: Iterator<Item=I::Item>,
 {
@@ -559,8 +588,9 @@ impl<K, I> EnumerateFrom<I, K> where
     }
 }
 
-impl<K, I: Iterator> Iterator for EnumerateFrom<I, K> where
+impl<K, I> Iterator for EnumerateFrom<I, K> where
     K: Int,
+    I: Iterator,
 {
     type Item = (K, I::Item);
     fn next(&mut self) -> Option<(K, I::Item)>
@@ -571,7 +601,7 @@ impl<K, I: Iterator> Iterator for EnumerateFrom<I, K> where
                 let index = self.index.clone();
                 // FIXME: Arithmetic needs to be wrapping here to be sane,
                 // imagine i8 counter to enumerate a sequence 0 to 127 inclusive.
-                self.index = self.index + <K as Int>::one();
+                self.index = self.index + K::one();
                 Some((index, elt))
             }
         }
@@ -579,7 +609,9 @@ impl<K, I: Iterator> Iterator for EnumerateFrom<I, K> where
 }
 
 /// An Iterator adaptor that allows the user to peek at multiple *.next()* values without advancing itself.
-pub struct MultiPeek<I: Iterator> {
+pub struct MultiPeek<I> where
+    I: Iterator,
+{
     iter: Fuse<I>,
     buf: Vec<I::Item>,
     index: usize,
@@ -593,7 +625,7 @@ impl<I: Iterator> MultiPeek<I> {
 
     /// Works exactly like *.next()* with the only difference that it doesn't advance itself.
     /// *.peek()* kann be called multiple times, behaving exactly like *.next()*.
-    pub fn peek(&mut self) -> Option<&<I as Iterator>::Item> {
+    pub fn peek(&mut self) -> Option<&I::Item> {
         let ret = if self.index < self.buf.len() {
             Some(&self.buf[self.index])
         } else {
@@ -611,10 +643,12 @@ impl<I: Iterator> MultiPeek<I> {
     }
 }
 
-impl<I: Iterator> Iterator for MultiPeek<I> {
+impl<I> Iterator for MultiPeek<I> where
+    I: Iterator,
+{
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<<I as Iterator>::Item> {
+    fn next(&mut self) -> Option<I::Item> {
         self.index = 0;
         if self.buf.is_empty() {
             self.iter.next()
@@ -626,8 +660,8 @@ impl<I: Iterator> Iterator for MultiPeek<I> {
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
-impl<I: Iterator> Clone for MultiPeek<I> where
-    I: Clone,
+impl<I> Clone for MultiPeek<I> where
+    I: Iterator + Clone,
     I::Item: Clone
 {
     fn clone(&self) -> Self

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -17,20 +17,23 @@ macro_rules! clone_fields {
 /// between each element of the adapted iterator.
 ///
 /// Iterator element type is **I::Item**
-pub struct Intersperse<I: Iterator> {
+pub struct Intersperse<I> where
+    I: Iterator,
+{
     element: I::Item,
     iter: I,
     peek: Option<I::Item>,
 }
 
-impl<I: Iterator> Clone for Intersperse<I> where
-    I: Clone,
+impl<I> Clone for Intersperse<I> where
+    I: Iterator + Clone,
     I::Item: Clone,
 {
     clone_fields!(Intersperse, element, iter, peek);
 }
 
-impl<I: Iterator> Intersperse<I>
+impl<I> Intersperse<I> where
+    I: Iterator,
 {
     /// Create a new Intersperse iterator
     pub fn new(mut iter: I, elt: I::Item) -> Self
@@ -39,7 +42,8 @@ impl<I: Iterator> Intersperse<I>
     }
 }
 
-impl<I: Iterator> Iterator for Intersperse<I> where
+impl<I> Iterator for Intersperse<I> where
+    I: Iterator,
     I::Item: Clone,
 {
     type Item = I::Item;

--- a/src/islice.rs
+++ b/src/islice.rs
@@ -41,9 +41,9 @@ impl<I> ISlice<I>
 impl<I> Iterator for ISlice<I>
     where I: Iterator
 {
-    type Item = <I as Iterator>::Item;
+    type Item = I::Item;
 
-    fn next(&mut self) -> Option<<I as Iterator>::Item>
+    fn next(&mut self) -> Option<I::Item>
     {
         if self.start != 0 {
             let st = self.start;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,8 @@ pub trait Itertools : Iterator {
     /// are run out
     ///
     /// Iterator element type is **Item**.
-    fn interleave<J: Iterator<Item=Self::Item>>(self, other: J) -> Interleave<Self, J> where
+    fn interleave<J>(self, other: J) -> Interleave<Self, J> where
+        J: Iterator<Item=Self::Item>,
         Self: Sized
     {
         Interleave::new(self, other)
@@ -229,7 +230,8 @@ pub trait Itertools : Iterator {
     ///
     /// Iterator element type is **EitherOrBoth\<Item, B\>**.
     #[inline]
-    fn zip_longest<U: Iterator>(self, other: U) -> ZipLongest<Self, U> where
+    fn zip_longest<U>(self, other: U) -> ZipLongest<Self, U> where
+        U: Iterator,
         Self: Sized,
     {
         ZipLongest::new(self, other)
@@ -326,7 +328,8 @@ pub trait Itertools : Iterator {
     /// let mut it = repeat('a').slice(..3);
     /// assert_eq!(it.count(), 3);
     /// ```
-    fn slice<R: misc::GenericRange>(self, range: R) -> ISlice<Self> where
+    fn slice<R>(self, range: R) -> ISlice<Self> where
+        R: misc::GenericRange,
         Self: Sized,
     {
         ISlice::new(self, range)
@@ -666,8 +669,9 @@ impl<T: ?Sized> Itertools for T where T: Iterator { }
 ///
 /// Return the number of elements written.
 #[inline]
-pub fn write<'a, A: 'a, I: Iterator<Item=&'a mut A>, J: Iterator<Item=A>>
-    (mut to: I, from: J) -> usize
+pub fn write<'a, A: 'a, I, J>(mut to: I, from: J) -> usize where
+    I: Iterator<Item=&'a mut A>,
+    J: Iterator<Item=A>
 {
     let mut count = 0;
     for elt in from {

--- a/src/linspace.rs
+++ b/src/linspace.rs
@@ -19,7 +19,8 @@ pub type Linspace<F> = iter::Take<iter::Counter<F>>;
 ///            vec![0., 0.25, 0.5, 0.75, 1.0]);
 /// ```
 #[inline]
-pub fn linspace<F: Float>(a: F, b: F, n: usize) -> Linspace<F>
+pub fn linspace<F>(a: F, b: F, n: usize) -> Linspace<F> where
+    F: Float,
 {
     let nf: F = NumCast::from(n).unwrap();
     let step = (b - a)/(nf - Float::one());

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -59,15 +59,13 @@ impl<I> FlatTuples<I>
     }
 }
 
-impl<X, T, I>
-Iterator for FlatTuples<I>
-    where
-        I: Iterator<Item=(T, X)>,
-        T: AppendTuple<X>,
+impl<X, T, I> Iterator for FlatTuples<I> where
+    I: Iterator<Item=(T, X)>,
+    T: AppendTuple<X>,
 {
-    type Item = <T as AppendTuple<X>>::Result;
+    type Item = T::Result;
     #[inline]
-    fn next(&mut self) -> Option< <Self as Iterator>::Item>
+    fn next(&mut self) -> Option<<Self as Iterator>::Item>
     {
         self.iter.next().map(|(t, x)| t.append(x))
     }
@@ -77,13 +75,12 @@ Iterator for FlatTuples<I>
     }
 }
 
-impl<X, T, I> DoubleEndedIterator for FlatTuples<I>
-    where
-        I: DoubleEndedIterator<Item=(T, X)>,
-        T: AppendTuple<X>,
+impl<X, T, I> DoubleEndedIterator for FlatTuples<I> where
+    I: DoubleEndedIterator<Item=(T, X)>,
+    T: AppendTuple<X>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option< <Self as Iterator>::Item>
+    fn next_back(&mut self) -> Option<<Self as Iterator>::Item>
     {
         self.iter.next_back().map(|(t, x)| t.append(x))
     }

--- a/src/rciter.rs
+++ b/src/rciter.rs
@@ -24,7 +24,8 @@ impl<I> Clone for RcIter<I>
     }
 }
 
-impl<A, I: Iterator<Item=A>> Iterator for RcIter<I>
+impl<A, I> Iterator for RcIter<I> where
+    I: Iterator<Item=A>,
 {
     type Item = A;
     #[inline]
@@ -39,13 +40,16 @@ impl<A, I: Iterator<Item=A>> Iterator for RcIter<I>
     }
 }
 
-impl<I: DoubleEndedIterator> DoubleEndedIterator for RcIter<I>
+impl<I> DoubleEndedIterator for RcIter<I> where
+    I: DoubleEndedIterator,
 {
     #[inline]
-    fn next_back(&mut self) -> Option< <I as Iterator>::Item>
+    fn next_back(&mut self) -> Option<I::Item>
     {
         self.rciter.borrow_mut().next_back()
     }
 }
 
-impl<I: ExactSizeIterator> ExactSizeIterator for RcIter<I> {}
+impl<I> ExactSizeIterator for RcIter<I> where
+    I: ExactSizeIterator
+{}

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -27,8 +27,8 @@ pub struct Stride<'a, A: 'a> {
 }
 
 impl<'a, A> Copy for Stride<'a, A> {}
-unsafe impl<'a, A: Send> marker::Send for Stride<'a, A> {}
-unsafe impl<'a, A: Sync> marker::Sync for Stride<'a, A> {}
+unsafe impl<'a, A> Send for Stride<'a, A> where A: Send {}
+unsafe impl<'a, A> Sync for Stride<'a, A> where A: Sync {}
 
 /// StrideMut is like Stride, but with mutable elements.
 ///
@@ -41,8 +41,8 @@ pub struct StrideMut<'a, A: 'a> {
     life: marker::PhantomData<&'a mut A>,
 }
 
-unsafe impl<'a, A: Send> marker::Send for StrideMut<'a, A> {}
-unsafe impl<'a, A: Sync> marker::Sync for StrideMut<'a, A> {}
+unsafe impl<'a, A> Send for StrideMut<'a, A> where A: Send {}
+unsafe impl<'a, A> Sync for StrideMut<'a, A> where A: Sync {}
 
 impl<'a, A> Stride<'a, A>
 {
@@ -229,7 +229,8 @@ macro_rules! stride_impl {
             }
         }
 
-        impl<'a, A: fmt::Debug> fmt::Debug for $name<'a, A>
+        impl<'a, A> fmt::Debug for $name<'a, A>
+            where A: fmt::Debug
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
             {

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -13,13 +13,15 @@ struct TeeBuffer<A, I>
 }
 
 /// One half of an iterator pair where both return the same elements.
-pub struct Tee<I: Iterator>
+pub struct Tee<I> where
+    I: Iterator
 {
     rcbuffer: Rc<RefCell<TeeBuffer<I::Item, I>>>,
     id: bool,
 }
 
-pub fn new<I: Iterator>(iter: I) -> (Tee<I>, Tee<I>)
+pub fn new<I>(iter: I) -> (Tee<I>, Tee<I>) where
+    I: Iterator
 {
     let buffer = TeeBuffer{backlog: VecDeque::new(), iter: iter, owner: false};
     let t1 = Tee{rcbuffer: Rc::new(RefCell::new(buffer)), id: true};
@@ -27,7 +29,8 @@ pub fn new<I: Iterator>(iter: I) -> (Tee<I>, Tee<I>)
     (t1, t2)
 }
 
-impl<I: Iterator> Iterator for Tee<I> where
+impl<I> Iterator for Tee<I> where
+    I: Iterator,
     I::Item: Clone,
 {
     type Item = I::Item;

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -22,10 +22,9 @@ impl<T, U> ZipLongest<T, U>
     }
 }
 
-impl<A, B, T, U> Iterator for ZipLongest<T, U>
-    where
-        T: Iterator<Item=A>,
-        U: Iterator<Item=B>,
+impl<A, B, T, U> Iterator for ZipLongest<T, U> where
+    T: Iterator<Item=A>,
+    U: Iterator<Item=B>,
 {
     type Item = EitherOrBoth<A, B>;
     #[inline]
@@ -54,10 +53,9 @@ impl<A, B, T, U> Iterator for ZipLongest<T, U>
     }
 }
 
-impl<A, B, T, U> DoubleEndedIterator for ZipLongest<T, U>
-    where
-        T: DoubleEndedIterator<Item=A> + ExactSizeIterator,
-        U: DoubleEndedIterator<Item=B> + ExactSizeIterator,
+impl<A, B, T, U> DoubleEndedIterator for ZipLongest<T, U> where
+    T: DoubleEndedIterator<Item=A> + ExactSizeIterator,
+    U: DoubleEndedIterator<Item=B> + ExactSizeIterator,
 {
     #[inline]
     fn next_back(&mut self) -> Option<EitherOrBoth<A, B>> {
@@ -76,10 +74,9 @@ impl<A, B, T, U> DoubleEndedIterator for ZipLongest<T, U>
     }
 }
 
-impl<A, B, T, U> RandomAccessIterator for ZipLongest<T, U>
-    where
-        T: RandomAccessIterator<Item=A>,
-        U: RandomAccessIterator<Item=B>,
+impl<A, B, T, U> RandomAccessIterator for ZipLongest<T, U> where
+    T: RandomAccessIterator<Item=A>,
+    U: RandomAccessIterator<Item=B>,
 {
     #[inline]
     fn indexable(&self) -> usize {
@@ -97,8 +94,10 @@ impl<A, B, T, U> RandomAccessIterator for ZipLongest<T, U>
     }
 }
 
-impl<T, U> ExactSizeIterator for ZipLongest<T, U>
-    where T: ExactSizeIterator, U: ExactSizeIterator {}
+impl<T, U> ExactSizeIterator for ZipLongest<T, U> where
+    T: ExactSizeIterator,
+    U: ExactSizeIterator,
+{}
 
 
 /// A value yielded by `ZipLongest`.

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -49,10 +49,10 @@ macro_rules! impl_zip_iter {
                 $B: Iterator,
             )*
         {
-            type Item = ($(<$B as Iterator>::Item,)*);
+            type Item = ($($B::Item,)*);
 
             fn next(&mut self) -> Option<
-                    ($(<$B as Iterator>::Item,)*)
+                    ($($B::Item,)*)
                 >
             {
                 let &mut Zip { t : ($(ref mut $B,)*)} = self;
@@ -207,7 +207,7 @@ macro_rules! impl_zip_trusted {
                 $B: TrustedIterator,
             )*
         {
-            type Item = ($(<$B as Iterator>::Item,)*);
+            type Item = ($($B::Item,)*);
 
             fn next(&mut self) -> Option<<Self as Iterator>::Item>
             {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -19,10 +19,10 @@ use itertools::Zip;
 
 use itertools as it;
 
-fn assert_iters_equal<
+fn assert_iters_equal<A, I, J>(mut it: I, mut jt: J) where
     A: PartialEq + Debug,
     I: Iterator<Item=A>,
-    J: Iterator<Item=A>>(mut it: I, mut jt: J)
+    J: Iterator<Item=A>,
 {
     loop {
         let elti = it.next();

--- a/tests/zip.rs
+++ b/tests/zip.rs
@@ -43,7 +43,9 @@ fn test_double_ended_zip_longest() {
 
 // This function copied from std::iter in rust-lang/rust
 #[cfg(test)]
-fn check_randacc_iter<A: PartialEq, T: Clone + Iterator<Item=A> + RandomAccessIterator>(a: T, len: usize)
+fn check_randacc_iter<A, T>(a: T, len: usize) where
+    A: PartialEq,
+    T: Clone + Iterator<Item=A> + RandomAccessIterator
 {
     let mut b = a.clone();
     assert_eq!(len, b.indexable());


### PR DESCRIPTION
... `where I: Trait` .... `I::AssocType` now works. This is purely a style cleanup but touches everything. I won't be offended if you don't want it.