### PR TITLE
Add sort_by iterator adapter.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,6 +1058,37 @@ pub trait Itertools : Iterator {
             None
         }
     }
+
+    /// Sort iterator elements.
+    ///
+    /// **Note:** This consumes the entire iterator, uses the
+    /// **slice::sort_by()** function and returns the sorted vector.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// // sort people in descending order by age
+    /// let people = vec![("Jane", 20), ("John", 18), ("Jill", 30), ("Jack", 27)];
+    ///
+    /// let oldest_people_first = people
+    ///     .into_iter()
+    ///     .sort_by(|&a, &b| {
+    ///         a.1.cmp(&b.1).reverse()
+    ///     })
+    ///     .into_iter()
+    ///     .map(|(person, _age)| person)
+    ///     .collect::<Vec<_>>();
+    ///
+    /// assert_eq!(oldest_people_first, vec!["Jill", "Jack", "Jane", "John"]);
+    /// ```
+    fn sort_by<F: FnMut(&Self::Item, &Self::Item) -> Ordering>(self, cmp: F) -> Vec<Self::Item> where
+        Self: Sized
+    {
+        let mut v: Vec<Self::Item> = self.collect();
+
+        v.sort_by(cmp);
+        v
+    }
 }
 
 impl<T: ?Sized> Itertools for T where T: Iterator { }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -385,6 +385,17 @@ fn join() {
 }
 
 #[test]
+fn sort_by() {
+    let sc = [3, 4, 1, 2].iter().cloned().sort_by(|&a, &b| {
+        a.cmp(&b)
+    });
+    assert_eq!(sc, vec![1, 2, 3, 4]);
+
+    let v = (0..5).sort_by(|&a, &b| a.cmp(&b).reverse());
+    assert_eq!(v, vec![4, 3, 2, 1, 0]);
+}
+
+#[test]
 fn multipeek() {
     let nums = vec![1u8,2,3,4,5];
 


### PR DESCRIPTION
The existing `sort_by()` function in core does the sorting in place. This
breaks apart iterator chaining. This adapter removes the boilerplate of
collecting the existing iterator, sorting it and then turning it back
into an iterator.