### PR TITLE
.unique() and .unique_by(..) operations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ use std::iter::{self, IntoIterator};
 use std::fmt::Write;
 use std::cmp::Ordering;
 use std::fmt;
+use std::hash::Hash;
 
 pub use adaptors::{
     Interleave,
@@ -54,6 +55,8 @@ pub use adaptors::{
     Coalesce,
     CoalesceFn,
     Combinations,
+    Unique,
+    UniqueBy,
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
@@ -625,6 +628,45 @@ pub trait Itertools : Iterator {
         Coalesce::new(self, eq)
     }
 
+    /// Filter non-unique elements from the iterator.
+    ///
+    /// Copies of visited elements are stored in a hash set in the
+    /// iterator.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![10, 20, 30, 20, 40, 10, 50];
+    /// itertools::assert_equal(data.into_iter().unique(),
+    ///                         vec![10, 20, 30, 40, 50]);
+    /// ```
+    fn unique(self) -> Unique<Self> where
+        Self: Sized,
+        Self::Item: Clone + Eq + Hash,
+    {
+        self.unique_by(Clone::clone)
+    }
+
+    /// Filter non-unique elements from the iterator.
+    ///
+    /// Elemens are considered the same if supplied function returns
+    /// equal values for them. Those values are stored in a hash set in
+    /// the iterator.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec!["a", "bb", "aa", "c", "ccc"];
+    /// itertools::assert_equal(data.into_iter().unique_by(|s| s.len()),
+    ///                         vec!["a", "bb", "ccc"]);
+    /// ```
+    fn unique_by<V, F>(self, f: F) -> UniqueBy<Self, V, F> where
+        Self: Sized,
+        V: Clone + Eq + Hash,
+        F: FnMut(&Self::Item) -> V
+    {
+        UniqueBy::new(self, f)
+    }
 
     /// Return an iterator adaptor that joins together adjacent slices if possible.
     ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -203,6 +203,23 @@ fn dedup() {
 }
 
 #[test]
+fn unique_by() {
+    let xs = ["aaa", "bbbbb", "aa", "ccc", "bbbb", "aaaaa", "cccc"];
+    let ys = ["aaa", "bbbbb", "ccc"];
+    it::assert_equal(ys.iter(), xs.iter().unique_by(|x| x[..2].to_string()));
+}
+
+#[test]
+fn unique() {
+    let xs = [0, 1, 2, 3, 2, 1, 3];
+    let ys = [0, 1, 2, 3];
+    it::assert_equal(ys.iter(), xs.iter().unique());
+    let xs = [0, 1];
+    let ys = [0, 1];
+    it::assert_equal(ys.iter(), xs.iter().unique());
+}
+
+#[test]
 fn batching() {
     let xs = [0, 1, 2, 1, 3];
     let ys = [(0, 1), (2, 1)];


### PR DESCRIPTION
Functions make iterators that return unique elements, storing visited
elements in a hash set.

`.unique_by(..)` uses supplied function to make keys, and `.unique()`
uses `.clone()`.