### PR TITLE
Add .group_by_lazy()

### DIFF
--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -49,6 +49,8 @@ impl<K, I, F> GroupInner<K, I, F>
                 }
             }
             elt
+        } else if self.done {
+            return None;
         } else if self.top == client {
             self.step_current()
         } else {
@@ -101,9 +103,7 @@ impl<K, I, F> GroupInner<K, I, F>
 
     /// This is the immediate case, where we use no buffering
     fn step_current(&mut self) -> Option<I::Item> {
-        if self.done {
-            return None;
-        }
+        debug_assert!(!self.done);
         if let elt @ Some(..) = self.current_elt.take() {
             return elt;
         }

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -1,0 +1,287 @@
+use Itertools;
+use std::mem;
+use std::cell::{Cell, RefCell};
+use std::vec;
+
+struct GroupInner<K, I, F>
+    where I: Iterator,
+{
+    key: F,
+    iter: I,
+    current_key: Option<K>,
+    current_elt: Option<I::Item>,
+    // buffering stuff
+    done: bool,
+    /// Index of group we are currently buffering or visiting
+    top: usize,
+    /// Least index for which we still have elements buffered
+    bot: usize,
+
+    /// Buffered groups, from `bot` (index 0) to `top`.
+    buffer: Vec<vec::IntoIter<I::Item>>,
+    /// index of last subgroup iter that was dropped
+    dropped_group: Option<usize>,
+}
+
+impl<K, I, F> GroupInner<K, I, F>
+    where I: Iterator,
+          F: FnMut(&I::Item) -> K,
+          K: PartialEq,
+{
+    /// `client`: Index of subgroup that requests next element
+    fn step(&mut self, client: usize) -> Option<I::Item> {
+        /*
+        println!("client={}, bot={}, top={}, buffers={:?}",
+                 client, self.bot, self.top,
+                 self.buffer.iter().map(|x| x.len()).collect::<Vec<_>>());
+         */
+        if client < self.bot {
+            None
+        } else if client < self.top ||
+            (client == self.top && self.buffer.len() > self.top - self.bot)
+        {
+            let bufidx = client - self.bot;
+            let elt = self.buffer[bufidx].next();
+            if elt.is_none() {
+                while self.buffer.len() > 0 && self.buffer[0].len() == 0 {
+                    self.buffer.remove(0);
+                    self.bot += 1;
+                }
+            }
+            elt
+        } else if self.top == client {
+            self.step_current()
+        } else {
+            // requested a later subgroup -- walk through all groups up to
+            // the requested group index, and buffer the elements (unless
+            // the group is marked as dropped).
+            let mut group = Vec::new();
+
+            if let Some(elt) = self.current_elt.take() {
+                if self.dropped_group != Some(self.top) {
+                    group.push(elt);
+                }
+            }
+            loop {
+                match self.iter.next() {
+                    None => {
+                        if group.len() > 0 && self.dropped_group != Some(self.top) {
+                            self.buffer.push(group.into_iter());
+                            debug_assert!(self.top - self.bot + 1 == self.buffer.len());
+                        }
+                        self.done = true;
+                        return None;
+                    }
+                    Some(elt) => {
+                        let key = (self.key)(&elt);
+                        match self.current_key.take() {
+                            None => {}
+                            Some(old_key) => if old_key != key {
+                                if group.len() > 0 && self.dropped_group != Some(self.top) {
+                                    let this_group = mem::replace(&mut group, Vec::new());
+                                    self.buffer.push(this_group.into_iter());
+                                    debug_assert!(self.top - self.bot + 1 == self.buffer.len());
+                                }
+                                self.top += 1;
+                                if self.top == client {
+                                    self.current_key = Some(key);
+                                    return Some(elt);
+                                }
+                            },
+                        }
+                        self.current_key = Some(key);
+                        if self.dropped_group != Some(self.top) {
+                            group.push(elt);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// This is the immediate case, where we use no buffering
+    fn step_current(&mut self) -> Option<I::Item> {
+        if self.done {
+            return None;
+        }
+        if let elt @ Some(..) = self.current_elt.take() {
+            return elt;
+        }
+        match self.iter.next() {
+            None => {
+                self.done = true;
+                return None;
+            }
+            Some(elt) => {
+                let key = (self.key)(&elt);
+                match self.current_key.take() {
+                    None => {}
+                    Some(old_key) => if old_key != key {
+                        self.current_key = Some(key);
+                        self.current_elt = Some(elt);
+                        self.bot += 1;
+                        self.top += 1;
+                        return None;
+                    },
+                }
+                self.current_key = Some(key);
+                Some(elt)
+            }
+        }
+    }
+}
+
+impl<K, I, F> GroupInner<K, I, F>
+    where I: Iterator,
+{
+    /// Called when a subgroup is dropped
+    fn drop_subgroup(&mut self, client: usize) {
+        self.dropped_group = Some(client);
+    }
+}
+
+/// `GroupByLazy` is the storage for the lazy grouping operation.
+///
+/// If the subgroups are consumed in their original order, or if each
+/// subgroup is dropped without keeping it around, then `GroupByLazy` uses
+/// no allocations. It needs allocations only if several group iterators
+/// are alive at the same time.
+///
+/// This type implements `IntoIterator` (it is **not** an iterator
+/// itself), because the subgroup iterators need to borrow from this
+/// value. It should stored in a local variable or temporary and
+/// iterated.
+///
+/// See [`.group_by_lazy()`](trait.Itertools.html#method.group_by_lazy) for more information.
+pub struct GroupByLazy<K, I, F>
+    where I: Iterator,
+{
+    inner: RefCell<GroupInner<K, I, F>>,
+    // the subgroup iterator's current index. Keep this in the main value
+    // so that simultaneous iterators all use the same state.
+    index: Cell<usize>,
+}
+
+/// Create a new
+pub fn new<K, J, F>(iter: J, f: F) -> GroupByLazy<K, J::IntoIter, F>
+    where J: IntoIterator,
+          F: FnMut(&J::Item) -> K,
+{
+    GroupByLazy {
+        inner: RefCell::new(GroupInner {
+            key: f,
+            iter: iter.into_iter(),
+            current_key: None,
+            current_elt: None,
+            done: false,
+            top: 0,
+            bot: 0,
+            buffer: Vec::new(),
+            dropped_group: None,
+        }),
+        index: Cell::new(0),
+    }
+}
+
+impl<K, I, F> GroupByLazy<K, I, F>
+    where I: Iterator,
+{
+    /// `client`: Index of subgroup that requests next element
+    fn step(&self, client: usize) -> Option<I::Item> 
+        where F: FnMut(&I::Item) -> K,
+              K: PartialEq,
+    {
+        self.inner.borrow_mut().step(client)
+    }
+
+    /// `client`: Index of subgroup
+    fn drop_subgroup(&self, client: usize) {
+        self.inner.borrow_mut().drop_subgroup(client)
+    }
+}
+
+impl<'a, K, I, F> IntoIterator for &'a GroupByLazy<K, I, F>
+    where I: Iterator,
+          I::Item: 'a,
+          F: FnMut(&I::Item) -> K,
+          K: PartialEq,
+{
+    type Item = Group<'a, K, I, F>;
+    type IntoIter = Groups<'a, K, I, F>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Groups {
+            parent: self,
+        }
+    }
+}
+
+
+/// An iterator that yields the roup iterators.
+///
+/// Iterator element type is `Group<'a, K, I, F>`, another iterator.
+pub struct Groups<'a, K: 'a, I: 'a, F: 'a>
+    where I: Iterator,
+          I::Item: 'a,
+{
+    parent: &'a GroupByLazy<K, I, F>,
+}
+
+impl<'a, K, I, F> Iterator for Groups<'a, K, I, F>
+    where I: Iterator,
+          I::Item: 'a,
+          F: FnMut(&I::Item) -> K,
+          K: PartialEq,
+{
+    type Item = Group<'a, K, I, F>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.parent.index.get();
+        self.parent.index.set(index + 1);
+        self.parent.step(index).map(|elt| {
+            Group {
+                parent: self.parent,
+                index: index,
+                first: Some(elt),
+            }
+        })
+    }
+}
+
+/// An iterator for the elements in a single group.
+///
+/// Iterator element type is `I::Item`.
+pub struct Group<'a, K: 'a, I: 'a, F: 'a>
+    where I: Iterator,
+          I::Item: 'a,
+{
+    parent: &'a GroupByLazy<K, I, F>,
+    index: usize,
+    first: Option<I::Item>,
+}
+
+impl<'a, K, I, F> Drop for Group<'a, K, I, F>
+    where I: Iterator,
+          I::Item: 'a,
+{
+    fn drop(&mut self) {
+        self.parent.drop_subgroup(self.index);
+    }
+}
+
+impl<'a, K, I, F> Iterator for Group<'a, K, I, F>
+    where I: Iterator,
+          I::Item: 'a,
+          F: FnMut(&I::Item) -> K,
+          K: PartialEq,
+{
+    type Item = I::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let elt @ Some(..) = self.first.take() {
+            return elt;
+        }
+        self.parent.step(self.index)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub use adaptors::{
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
+pub use groupbylazy::{GroupByLazy, Group, Groups};
 pub use intersperse::Intersperse;
 pub use islice::{ISlice};
 pub use pad_tail::PadUsing;
@@ -84,6 +85,7 @@ pub use ziptuple::{Zip};
 #[cfg(feature = "unstable")]
 pub use ziptrusted::{ZipTrusted, TrustedIterator};
 mod adaptors;
+mod groupbylazy;
 mod intersperse;
 mod islice;
 mod linspace;
@@ -361,6 +363,28 @@ pub trait Itertools : Iterator {
         Self: Sized,
     {
         GroupBy::new(self, key)
+    }
+
+    /// Return an iterable that can group iterator elements.
+    ///
+    /// `GroupByLazy` is the storage for the lazy grouping operation.
+    ///
+    /// If the subgroups are consumed in their original order, or if each
+    /// subgroup is dropped without keeping it around, then `GroupByLazy` uses
+    /// no allocations. It needs allocations only if several group iterators
+    /// are alive at the same time.
+    ///
+    /// This type implements `IntoIterator` (it is **not** an iterator
+    /// itself), because the subgroup iterators need to borrow from this
+    /// value. It should stored in a local variable or temporary and
+    /// iterated.
+    ///
+    /// Iterator element type is `Groups` (an iterator).
+    fn group_by_lazy<K, F>(self, key: F) -> GroupByLazy<K, Self, F>
+        where Self: Sized,
+              F: FnMut(&Self::Item) -> K,
+    {
+        groupbylazy::new(self, key)
     }
 
     /// Split into an iterator pair that both yield all elements from

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -472,4 +472,12 @@ fn size_unique(it: Iter<i8>) -> bool {
     correct_size_hint(it.unique())
 }
 
+#[quickcheck]
+fn fuzz_group_by_lazy(it: Iter<u8>) -> bool {
+    let jt = it.clone();
+    let groups = it.group_by_lazy(|k| *k);
+    let res = itertools::equal(jt, groups.into_iter().flat_map(|x| x));
+    res
+}
+
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -629,3 +629,103 @@ fn while_some() {
                     .while_some();
     it::assert_equal(ns, vec![1, 2, 3, 4]);
 }
+
+#[test]
+fn group_by_lazy() {
+    for sub in &"AABBCCC".chars().group_by_lazy(|&x| x) {
+        for ch in sub {
+            println!("{}", ch);
+        }
+    }
+
+    println!("take two");
+
+    for (i, sub) in (&"AAABBBCCCCDDDD".chars().group_by_lazy(|&x| x)).into_iter().enumerate() {
+        for ch in sub {
+            println!("{}", ch);
+            if i % 2 == 0 {
+                break;
+            }
+        }
+    }
+
+    let groups = "AAABBBCCCCDDDD".chars().group_by_lazy(|&x| x);
+    let mut subs = Vec::new();
+    for sub in &groups {
+        subs.push(sub);
+    }
+    //subs.pop();
+    it::assert_equal(subs.pop().unwrap(), "DDDD".chars());
+    it::assert_equal(subs.pop().unwrap(), "CCCC".chars());
+    it::assert_equal(subs.pop().unwrap(), "BBB".chars());
+    it::assert_equal(subs.pop().unwrap(), "AAA".chars());
+
+    let groups = "AaaBbbccCcDDDD".chars().group_by_lazy(|x| x.to_uppercase().nth(0).unwrap());
+    let mut subs = Vec::new();
+    for sub in &groups {
+        subs.push(sub);
+    }
+
+    for (i, sub) in subs.into_iter().enumerate() {
+        match i {
+            0 => it::assert_equal(sub, "Aaa".chars()),
+            1 => it::assert_equal(sub, "Bbb".chars()),
+            2 => it::assert_equal(sub, "ccCc".chars()),
+            _ => it::assert_equal(sub, "DDDD".chars()),
+        }
+    }
+
+    let groups = "AAABBBCCCCDDDD".chars().group_by_lazy(|&x| x);
+    let mut subs = Vec::new();
+    for sub in &groups {
+        subs.push(sub);
+    }
+    let sd = subs.pop().unwrap();
+    let sc = subs.pop().unwrap();
+    let sb = subs.pop().unwrap();
+    let sa = subs.pop().unwrap();
+    for (a, b, c, d) in Zip::new((sa, sb, sc, sd)) {
+        assert_eq!(a, 'A');
+        assert_eq!(b, 'B');
+        assert_eq!(c, 'C');
+        assert_eq!(d, 'D');
+    }
+
+    let groups = "AaaBbbccCcDDDD".chars().group_by_lazy(|x| x.to_uppercase().nth(0).unwrap());
+    let mut it = groups.into_iter();
+    let a = it.next().unwrap();
+    let b = it.next().unwrap();
+    it::assert_equal(a, "Aaa".chars());
+    it::assert_equal(b, "Bbb".chars());
+    let c = it.next().unwrap();
+    let d = it.next().unwrap();
+    it::assert_equal(d, "DDDD".chars());
+    it::assert_equal(c, "ccCc".chars());
+    assert!(it.next().is_none());
+
+    // check that the closure is called exactly n times
+    {
+        let mut ntimes = 0;
+        let text = "AABCCC";
+        for sub in &text.chars().group_by_lazy(|&x| { ntimes += 1; x}) {
+            for _ in sub {
+            }
+        }
+        assert_eq!(ntimes, text.len());
+    }
+
+    {
+        let mut ntimes = 0;
+        let text = "AABCCC";
+        for _ in &text.chars().group_by_lazy(|&x| { ntimes += 1; x}) {
+        }
+        assert_eq!(ntimes, text.len());
+    }
+
+    {
+        let text = "AABCCC";
+        let gr = text.chars().group_by_lazy(|&x| x);
+        it::assert_equal(gr.into_iter().flat_map(|sub| sub),
+                         text.chars());
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -729,3 +729,43 @@ fn group_by_lazy() {
                          text.chars());
     }
 }
+
+#[test]
+fn group_by_lazy_2() {
+    let data = vec![0, 1];
+    let groups = data.iter().group_by_lazy(|k| *k);
+    let gs = groups.into_iter().collect_vec();
+    it::assert_equal(data.iter(), gs.into_iter().flat_map(|g| g));
+
+    let data = vec![0, 1, 1, 0, 0];
+    let groups = data.iter().group_by_lazy(|k| *k);
+    let mut gs = groups.into_iter().collect_vec();
+    gs[1..].reverse();
+    it::assert_equal(&[0, 0, 0, 1, 1], gs.into_iter().flat_map(|g| g));
+
+    let grouper = data.iter().group_by_lazy(|k| *k);
+    let mut groups = Vec::new();
+    for (i, group) in grouper.into_iter().enumerate() {
+        if i == 1 {
+            groups.push(group);
+        }
+    }
+    it::assert_equal(&mut groups[0], &[1, 1]);
+
+    let data = vec![0, 0, 0, 1, 1, 0, 0, 2, 2, 3, 3];
+    let grouper = data.iter().group_by_lazy(|k| *k);
+    let mut groups = Vec::new();
+    for (i, group) in grouper.into_iter().enumerate() {
+        if i < 2 {
+            groups.push(group);
+        } else if i < 4 {
+            for _ in group {
+            }
+        } else {
+            groups.push(group);
+        }
+    }
+    it::assert_equal(&mut groups[0], &[0, 0, 0]);
+    it::assert_equal(&mut groups[1], &[1, 1]);
+    it::assert_equal(&mut groups[2], &[3, 3]);
+}


### PR DESCRIPTION
`GroupByLazy` is the storage for the lazy grouping operation.

If the groups are consumed in order, or if each group's iterator is
dropped without keeping it around, then `GroupByLazy` uses no
allocations.  It needs allocations only if several group iterators
are alive at the same time.

This type implements `IntoIterator` (it is **not** an iterator
itself), because the group iterators need to borrow from this
value. It should stored in a local variable or temporary and
iterated.

Iterator element type is `Group` (an iterator).

cc @DanielKeep @eddyb, what do you think?
The iterator value is really fat, but in most common cases it will
not buffer anything and then it uses no allocations.