### PR TITLE
Improve .merge()

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -573,6 +573,17 @@ pub struct Merge<I, J, F> where
     fused: Option<bool>,
 }
 
+// default ordering function for .merge()
+// Note: To be replaced by unit struct
+#[inline]
+pub fn merge_default_ordering<A: PartialOrd>(a: &A, b: &A) -> Ordering {
+    if a > b {
+        Ordering::Greater
+    } else {
+        Ordering::Less
+    }
+}
+
 impl<I, J, F> Merge<I, J, F> where
     I: Iterator,
     J: Iterator<Item=I::Item>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,10 +570,7 @@ pub trait Itertools : Iterator {
         Self::Item: PartialOrd,
         J: IntoIterator<Item=Self::Item>,
     {
-        fn wrapper<A: PartialOrd>(a: &A, b: &A) -> Ordering {
-            a.partial_cmp(b).unwrap_or(Ordering::Less)
-        };
-        self.merge_by(other, wrapper)
+        self.merge_by(other, adaptors::merge_default_ordering)
     }
 
     /// Return an iterator adaptor that merges the two base iterators in order.

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -195,7 +195,11 @@ impl<'a> MendSlice for &'a str
 }
 
 /// A helper trait to let `ZipSlices` accept both `&[T]` and `&mut [T]`.
-pub trait Slice {
+///
+/// Unsafe trait because:
+///
+/// - Implementors must guarantee that `get_unchecked` is valid for all indices `0..len()`.
+pub unsafe trait Slice {
     /// The type of a reference to the slice's elements
     type Item;
     #[doc(hidden)]
@@ -204,7 +208,7 @@ pub trait Slice {
     unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item;
 }
 
-impl<'a, T> Slice for &'a [T] {
+unsafe impl<'a, T> Slice for &'a [T] {
     type Item = &'a T;
     #[inline(always)]
     fn len(&self) -> usize { (**self).len() }
@@ -215,7 +219,7 @@ impl<'a, T> Slice for &'a [T] {
     }
 }
 
-impl<'a, T> Slice for &'a mut [T] {
+unsafe impl<'a, T> Slice for &'a mut [T] {
     type Item = &'a mut T;
     #[inline(always)]
     fn len(&self) -> usize { (**self).len() }

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -247,7 +247,7 @@ macro_rules! stride_impl {
             }
         }
 
-        impl<'a, A> Slice for $name<'a, A> {
+        unsafe impl<'a, A> Slice for $name<'a, A> {
             type Item = $elem;
             fn len(&self) -> usize { $name::len(self) }
             unsafe fn get_unchecked(&mut self, i: usize) -> $elem {

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -29,7 +29,7 @@ pub struct Stride<'a, A: 'a> {
 }
 
 impl<'a, A> Copy for Stride<'a, A> {}
-unsafe impl<'a, A> Send for Stride<'a, A> where A: Send {}
+unsafe impl<'a, A> Send for Stride<'a, A> where A: Sync {}
 unsafe impl<'a, A> Sync for Stride<'a, A> where A: Sync {}
 
 /// The mutable equivalent of Stride.

--- a/src/zipslices.rs
+++ b/src/zipslices.rs
@@ -17,23 +17,12 @@ use misc::Slice;
 ///
 /// Iterator element type for `ZipSlices<T, U>` is `(T::Item, U::Item)`. For example,
 /// for a `ZipSlices<&'a [A], &'b mut [B]>`, the element type is `(&'a A, &'b mut B)`.
+#[derive(Clone)]
 pub struct ZipSlices<T, U> {
     t: T,
     u: U,
     len: usize,
     index: usize,
-}
-
-/// `ZipSlices` is only clonable if both slices are shared references (`&[_]`).
-impl<T: Copy, U: Copy> Clone for ZipSlices<T, U> {
-    fn clone(&self) -> Self {
-        ZipSlices {
-            t: self.t,
-            u: self.u,
-            len: self.len,
-            index: self.index,
-        }
-    }
 }
 
 impl<'a, 'b, A, B> ZipSlices<&'a [A], &'b [B]> {


### PR DESCRIPTION
Related to issue #47 

.merge() is slow partly due to bad codegen of calling `.partial_ord()`. Use `>` directly instead.