### PR TITLE
Add merge_join and hash_join

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["bluss"]
 
 description = "Extra iterator adaptors, iterator methods and macros."
 
-keywords = ["iterator", "data-structure", "zip", "product", "group-by"]
+keywords = ["iterator", "data-structure", "zip", "product", "group-by", "join"]
 
 [dependencies.quickcheck]
 version = "0.2.21"

--- a/src/hash_join.rs
+++ b/src/hash_join.rs
@@ -1,0 +1,474 @@
+//! SQL-like join implementation of two (non-sorted) iterators.
+//!
+//! The hash join strategy requires the right iterator can be collected to a `HashMap`. The left
+//! iterator can be arbitrarily long. It is therefore asymmetric (iterators cannot be swapped), as
+//! distinct from [the merge join strategy](merge_join/index.html), which is symmetric.
+//!
+//! The fact that iterators do not need to be sorted makes it very efficient and particularly
+//! suitable for [star schema](https://en.wikipedia.org/wiki/Star_schema) or [snowflake
+//! schema](https://en.wikipedia.org/wiki/Snowflake_schema) joins.
+//!
+//! The supported join types:
+//!
+//! * [`INNER JOIN`](trait.Itertools.html#method.hash_join_inner) - an intersection between the
+//! left and the right iterator.
+//! * [`LEFT EXCL JOIN`](trait.Itertools.html#method.hash_join_left_excl) - a difference
+//! between the left and the right iterator (not directly in SQL).
+//! * [`LEFT OUTER JOIN`](trait.Itertools.html#method.hash_join_left_outer) - a union of `INNER
+//! JOIN` and `LEFT EXCL JOIN`.
+//! * [`RIGHT EXCL JOIN`](trait.Itertools.html#method.hash_join_right_excl) - a difference
+//! between the right and the left iterator (not directly in SQL).
+//! * [`RIGHT OUTER JOIN`](trait.Itertools.html#method.hash_join_right_outer) - a union of `INNER
+//! JOIN` and `RIGHT EXCL JOIN`.
+//! * [`FULL OUTER JOIN`](trait.Itertools.html#method.hash_join_full_outer) - a union of `INNER
+//! JOIN`, `LEFT EXCL JOIN` and `RIGHT EXCL JOIN`.
+
+use std::collections::hash_map::{HashMap, IntoIter,};
+use std::mem;
+use std::rc::Rc;
+use std::hash::Hash;
+use super::EitherOrBoth::{self, Right, Left, Both};
+
+/// An iterator adaptor that [inner
+/// joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Inner_join) the two base iterators. The
+/// resulting iterator is the intersection of the two base iterators.
+///
+/// The base iterators do *not* need to be sorted. The right base iterator is loaded into HashMap
+/// and thus must be unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by), if necessary) to produce the correct
+/// results. The left base iterator do not need to be unique on the key.
+///
+/// The left base iterator element type must be `(K, LV)`, where `K: Hash + Eq`. 
+/// The right base iterator element type must be `(K, RV)`, where `K: Hash + Eq`.
+///
+/// Iterator element type is `(LV, std::rc::Rc<RV>)`.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct HashJoinInner<L, K, RV> {
+    left: L,
+    map: HashMap<K, Rc<RV>>,
+}
+
+impl<L, K, RV> HashJoinInner<L, K, RV> 
+    where K: Hash + Eq,
+{
+    /// Create a `HashJoinInner` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              RI: IntoIterator<Item=(K, RV)>
+    {
+        let mut map: HashMap<K, Rc<RV>> = HashMap::new();
+        for (k, v) in right.into_iter() {
+            map.insert(k, Rc::new(v));
+        }
+        HashJoinInner {
+            left: left.into_iter(),
+            map: map,
+        }
+    }
+}
+
+impl<L, K, LV, RV> Iterator for HashJoinInner<L, K, RV> 
+    where L: Iterator<Item=(K, LV)>,
+          K: Hash + Eq,
+{
+    type Item = (LV, Rc<RV>);
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.left.next() {
+                Some((lk, lv)) => match self.map.get(&lk) {
+                    Some(rv) => return Some((lv, rv.clone())),
+                    None => continue,
+                },
+                None => return None,
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that *left exclusive joins* the two base iterators. The resulting iterator
+/// contains only those records from the left input iterator, which do not match the right input
+/// iterator. There is no direct equivalent in SQL.
+///
+/// The base iterators do *not* need to be sorted. The right base iterator is loaded into HashMap
+/// and thus must be unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by), if necessary) to produce the correct
+/// results. The left base iterator do not need to be unique on the key.
+///
+/// The left base iterator element type must be `(K, LV)`, where `K: Hash + Eq`. 
+/// The right base iterator element type must be `(K, RV)`, where `K: Hash + Eq`.
+///
+/// Iterator element type is `LV`.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct HashJoinLeftExcl<L, K, RV> {
+    left: L,
+    map: HashMap<K, Rc<RV>>,
+}
+
+impl<L, K, RV> HashJoinLeftExcl<L, K, RV> 
+    where K: Hash + Eq,
+{
+    /// Create a `HashJoinLeftExcl` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              RI: IntoIterator<Item=(K, RV)>
+    {
+        let mut map: HashMap<K, Rc<RV>> = HashMap::new();
+        for (k, v) in right.into_iter() {
+            map.insert(k, Rc::new(v));
+        }
+        HashJoinLeftExcl {
+            left: left.into_iter(),
+            map: map,
+        }
+    }
+}
+
+impl<L, K, LV, RV> Iterator for HashJoinLeftExcl<L, K, RV> 
+    where L: Iterator<Item=(K, LV)>,
+          K: Hash + Eq,
+{
+    type Item = LV;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.left.next() {
+                Some((lk, lv)) => match self.map.get(&lk) {
+                    Some(_) => continue,
+                    None => return Some(lv),
+                },
+                None => return None,
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that [left outer
+/// joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Left_outer_join) the two base iterators.
+/// The resulting iterator contains all the records from the left input iterator, even if they do
+/// not match the right input iterator.
+///
+/// The base iterators do *not* need to be sorted. The right base iterator is loaded into HashMap
+/// and thus must be unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by), if necessary) to produce the correct
+/// results. The left base iterator do not need to be unique on the key.
+///
+/// The left base iterator element type must be `(K, LV)`, where `K: Hash + Eq`. 
+/// The right base iterator element type must be `(K, RV)`, where `K: Hash + Eq`.
+///
+/// Iterator element type is [`EitherOrBoth<LV, std::rc::Rc<RV>>`](enum.EitherOrBoth.html).
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct HashJoinLeftOuter<L, K, RV> {
+    left: L,
+    map: HashMap<K, Rc<RV>>,
+}
+
+impl<L, K, RV> HashJoinLeftOuter<L, K, RV> 
+    where K: Hash + Eq,
+{
+    /// Create a `HashJoinLeftOuter` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              RI: IntoIterator<Item=(K, RV)>
+    {
+        let mut map: HashMap<K, Rc<RV>> = HashMap::new();
+        for (k, v) in right.into_iter() {
+            map.insert(k, Rc::new(v));
+        }
+        HashJoinLeftOuter {
+            left: left.into_iter(),
+            map: map,
+        }
+    }
+}
+
+impl<L, K, LV, RV> Iterator for HashJoinLeftOuter<L, K, RV> 
+    where L: Iterator<Item=(K, LV)>,
+          K: Hash + Eq,
+{
+    type Item = EitherOrBoth<LV, Rc<RV>>;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.left.next() {
+                Some((lk, lv)) => match self.map.get(&lk) {
+                    Some(rv) => return Some(Both(lv, rv.clone())),
+                    None => return Some(Left(lv)),
+                },
+                None => return None,
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that *right exclusive joins* the two base iterators. The resulting iterator
+/// contains only those records from the right input iterator, which do not match the left input
+/// iterator. There is no direct equivalent in SQL.
+///
+/// The base iterators do *not* need to be sorted. The right base iterator is loaded into HashMap
+/// and thus must be unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by), if necessary) to produce the correct
+/// results. The left base iterator do not need to be unique on the key.
+///
+/// The left base iterator element type must be `(K, LV)`, where `K: Hash + Eq`. 
+/// The right base iterator element type must be `(K, RV)`, where `K: Hash + Eq`.
+///
+/// Iterator element type is `std::rc::Rc<RV>`.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct HashJoinRightExcl<L, K, RV> {
+    left: L,
+    map: HashMap<K, (Rc<RV>, bool)>,
+    /// exclusion iterator - yields the unmatched values from the map. It is created once the left
+    /// iterator is exhausted
+    excl_iter: Option<IntoIter<K, (Rc<RV>, bool)>>,
+}
+
+impl<L, K, RV> HashJoinRightExcl<L, K, RV> 
+    where K: Hash + Eq,
+{
+    /// Create a `HashJoinRightExcl` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              RI: IntoIterator<Item=(K, RV)>
+    {
+        let mut map: HashMap<K, (Rc<RV>, bool)> = HashMap::new();
+        for (k, v) in right.into_iter() {
+            map.insert(k, (Rc::new(v), false));
+        }
+        HashJoinRightExcl {
+            left: left.into_iter(),
+            map: map,
+            excl_iter: None,
+        }
+    }
+
+    /// Moves the map to `self.excl_iter`
+    ///
+    /// Once the left iterator is exhausted, the info about which keys were matched is complete.
+    /// To be able to iterate over map's values we need to move it into its `IntoIter`.
+    fn set_excl_iter(&mut self) {
+        let map = mem::replace(&mut self.map, HashMap::<K, (Rc<RV>, bool)>::new());
+        self.excl_iter = Some(map.into_iter());
+    }
+}
+
+impl<L, K, LV, RV> Iterator for HashJoinRightExcl<L, K, RV> 
+    where L: Iterator<Item=(K, LV)>,
+          K: Hash + Eq,
+{
+    type Item = Rc<RV>;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.excl_iter {
+                // the left iterator is not yet exhausted
+                None => match self.left.next() {
+                    Some((lk, _)) => match self.map.get_mut(&lk) {
+                        Some(rt) => {
+                            rt.1 = true; // flag as matched
+                        },
+                        None => continue, // not interested in unmatched left value
+                    },
+                    // the left iterator is exhausted so move the map into `self.excl_iter`.
+                    None => self.set_excl_iter(),
+                },
+                // iterate over unmatched values
+                Some(ref mut r) => match r.next() {
+                    Some((_, (rv, matched))) => {
+                        if !matched {
+                            return Some(rv.clone());
+                        } else {
+                            continue;
+                        }
+                    },
+                    None => return None,
+                }
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that [right outer
+/// joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Right_outer_join) the two base iterators.
+/// The resulting iterator contains all the records from the right input iterator, even if they do
+/// not match the left input iterator.
+///
+/// The base iterators do *not* need to be sorted. The right base iterator is loaded into HashMap
+/// and thus must be unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by), if necessary) to produce the correct
+/// results. The left base iterator do not need to be unique on the key.
+///
+/// The left base iterator element type must be `(K, LV)`, where `K: Hash + Eq`. 
+/// The right base iterator element type must be `(K, RV)`, where `K: Hash + Eq`.
+///
+/// Iterator element type is [`EitherOrBoth<LV, std::rc::Rc<RV>>`](enum.EitherOrBoth.html).
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct HashJoinRightOuter<L, K, RV> {
+    left: L,
+    map: HashMap<K, (Rc<RV>, bool)>,
+    /// exclusion iterator - yields the unmatched values from the map. It is created once the left
+    /// iterator is exhausted
+    excl_iter: Option<IntoIter<K, (Rc<RV>, bool)>>,
+}
+
+impl<L, K, RV> HashJoinRightOuter<L, K, RV> 
+    where K: Hash + Eq,
+{
+    /// Create a `HashJoinRightOuter` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              RI: IntoIterator<Item=(K, RV)>
+    {
+        let mut map: HashMap<K, (Rc<RV>, bool)> = HashMap::new();
+        for (k, v) in right.into_iter() {
+            map.insert(k, (Rc::new(v), false));
+        }
+        HashJoinRightOuter {
+            left: left.into_iter(),
+            map: map,
+            excl_iter: None,
+        }
+    }
+
+    /// Moves the map to `self.excl_iter`
+    ///
+    /// Once the left iterator is exhausted, the info about which keys were matched is complete.
+    /// To be able to iterate over map's values we need to move it into its `IntoIter`.
+    fn set_excl_iter(&mut self) {
+        let map = mem::replace(&mut self.map, HashMap::<K, (Rc<RV>, bool)>::new());
+        self.excl_iter = Some(map.into_iter());
+    }
+}
+
+impl<L, K, LV, RV> Iterator for HashJoinRightOuter<L, K, RV> 
+    where L: Iterator<Item=(K, LV)>,
+          K: Hash + Eq,
+          RV: Clone,
+{
+    type Item = EitherOrBoth<LV, Rc<RV>>;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.excl_iter {
+                // the left iterator is not yet exhausted
+                None => match self.left.next() {
+                    Some((lk, lv)) => match self.map.get_mut(&lk) {
+                        Some(rt) => {
+                            rt.1 = true; // flag as matched
+                            return Some(Both(lv, rt.0.clone()))
+                        },
+                        None => continue, // not interested in unmatched left value
+                    },
+                    // the left iterator is exhausted so move the map into `self.excl_iter`.
+                    None => self.set_excl_iter(),
+                },
+                // iterate over unmatched values
+                Some(ref mut r) => match r.next() {
+                    Some((_, (rv, matched))) => {
+                        if !matched {
+                            return Some(Right(rv));
+                        } else {
+                            continue;
+                        }
+                    },
+                    None => return None,
+                }
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that [full outer
+/// joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Full_outer_join) the two base iterators.
+/// The resulting iterator contains all the records from the both input iterators.
+///
+/// The base iterators do *not* need to be sorted. The right base iterator is loaded into HashMap
+/// and thus must be unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by), if necessary) to produce the correct
+/// results. The left base iterator do not need to be unique on the key.
+///
+/// The left base iterator element type must be `(K, LV)`, where `K: Hash + Eq`. 
+/// The right base iterator element type must be `(K, RV)`, where `K: Hash + Eq`.
+///
+/// Iterator element type is [`EitherOrBoth<LV, std::rc::Rc<RV>>`](enum.EitherOrBoth.html).
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct HashJoinFullOuter<L, K, RV> {
+    left: L,
+    map: HashMap<K, (Rc<RV>, bool)>,
+    /// exclusion iterator - yields the unmatched values from the map. It is created once the left
+    /// iterator is exhausted
+    excl_iter: Option<IntoIter<K, (Rc<RV>, bool)>>,
+}
+
+impl<L, K, RV> HashJoinFullOuter<L, K, RV> 
+    where K: Hash + Eq,
+{
+    /// Create a `HashJoinFullOuter` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              RI: IntoIterator<Item=(K, RV)>
+    {
+        let mut map: HashMap<K, (Rc<RV>, bool)> = HashMap::new();
+        for (k, v) in right.into_iter() {
+            map.insert(k, (Rc::new(v), false));
+        }
+        HashJoinFullOuter {
+            left: left.into_iter(),
+            map: map,
+            excl_iter: None,
+        }
+    }
+
+    /// Moves the map to `self.excl_iter`
+    ///
+    /// Once the left iterator is exhausted, the info about which keys were matched is complete.
+    /// To be able to iterate over map's values we need to move it into its `IntoIter`.
+    fn set_excl_iter(&mut self) {
+        let map = mem::replace(&mut self.map, HashMap::<K, (Rc<RV>, bool)>::new());
+        self.excl_iter = Some(map.into_iter());
+    }
+}
+
+impl<L, K, LV, RV> Iterator for HashJoinFullOuter<L, K, RV> 
+    where L: Iterator<Item=(K, LV)>,
+          K: Hash + Eq,
+          RV: Clone,
+{
+    type Item = EitherOrBoth<LV, Rc<RV>>;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.excl_iter {
+                // the left iterator is not yet exhausted
+                None => match self.left.next() {
+                    Some((lk, lv)) => match self.map.get_mut(&lk) {
+                        Some(rt) => {
+                            rt.1 = true; // flag as matched
+                            return Some(Both(lv, rt.0.clone()))
+                        },
+                        None => return Some(Left(lv)),
+                    },
+                    // the left iterator is exhausted so move the map into `self.excl_iter`.
+                    None => self.set_excl_iter(),
+                },
+                // iterate over unmatched values
+                Some(ref mut r) => match r.next() {
+                    Some((_, (rv, matched))) => {
+                        if !matched {
+                            return Some(Right(rv));
+                        } else {
+                            continue;
+                        }
+                    },
+                    None => return None,
+                }
+            }
+        }
+    }
+}

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -1,0 +1,320 @@
+//! SQL-like join implementation of two sorted iterators.
+//!
+//! The supported join types:
+//!
+//! * [`INNER JOIN`](trait.Itertools.html#method.merge_join_inner_by) - an intersection between the
+//! left and the right iterator.
+//! * [`LEFT EXCL JOIN`](trait.Itertools.html#method.merge_join_left_excl_by) - a difference
+//! between the left and the right iterator (not directly in SQL).
+//! * [`LEFT OUTER JOIN`](trait.Itertools.html#method.merge_join_left_outer_by) - a union of `INNER
+//! JOIN` and `LEFT EXCL JOIN`.
+//! * `RIGHT EXCL JOIN` - use the `LEFT EXCL JOIN` with left and right iterators swapped.
+//! * `RIGHT OUTER JOIN` - use the `LEFT OUTER JOIN` with left and right iterators swapped.
+//! * [`FULL OUTER JOIN`](trait.Itertools.html#method.merge_join_full_outer_by) - a union of `LEFT
+//! EXCL JOIN` , `INNER JOIN` and `RIGHT EXCL JOIN`.
+//!
+//! A merge join strategy requires the two iterators to be sorted, which might be costly. Therefore,
+//! if one of the iterators can be collected into memory, it is preferable to use a [hash
+//! join](hash_join/index.html).
+//!
+
+use std::iter::{Peekable,};
+use std::cmp::Ordering;
+use super::EitherOrBoth::{self, Right, Left, Both};
+ 
+/// An iterator adaptor that [inner
+/// joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Inner_join) the two base iterators in
+/// ascending order. The resulting iterator is the intersection of the two base iterators.
+///
+/// The both base iterators must be sorted (ascending) and unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by) them, if necessary) to produce the correct results.
+///
+/// Iterator element type is `(L::Item, R::Item)`.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct MergeJoinInner<L, R, F> 
+    where L: Iterator,
+          R: Iterator,
+{
+    left: Peekable<L>,
+    right: Peekable<R>,
+    cmp: F,
+}
+
+impl<L, R, F> MergeJoinInner<L, R, F>
+    where L: Iterator,
+          R: Iterator,
+{
+    /// Create a `MergeJoinInner` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI, cmp: F) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              R: Iterator<Item=RI::Item>,
+              RI: IntoIterator<IntoIter=R>,
+              F: FnMut(&L::Item, &R::Item) -> Ordering
+    {
+        MergeJoinInner {
+            left: left.into_iter().peekable(),
+            right: right.into_iter().peekable(),
+            cmp: cmp,
+        }
+    }
+}
+
+impl<L, R, F> Iterator for MergeJoinInner<L, R, F> 
+    where L: Iterator,
+          R: Iterator,
+          F: FnMut(&L::Item, &R::Item) -> Ordering
+{
+    type Item = (L::Item, R::Item);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let ord = match (self.left.peek(), self.right.peek()) {
+                (Some(l), Some(r)) => (self.cmp)(l, r),
+                _ => return None,
+            };
+
+            match ord {
+                Ordering::Less => {self.left.next();},
+                Ordering::Greater =>{self.right.next();},
+                Ordering::Equal => match (self.left.next(), self.right.next()) {
+                    (Some(l), Some(r)) => return Some((l, r)),
+                    _ => return None,
+                }
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that *left exclusive joins* the two base iterators in ascending order. The
+/// resulting iterator contains only those records from the left input iterator, which do not match
+/// the right input iterator. There is no direct equivalent in SQL.
+/// 
+/// The both base iterators must be sorted (ascending) and unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by) them, if necessary) to produce the correct results.
+///
+/// Iterator element type is `L::Item`.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct MergeJoinLeftExcl<L, R, F> where
+    L: Iterator,
+    R: Iterator,
+{
+    left: Peekable<L>,
+    right: Peekable<R>,
+    cmp: F,
+    fused: Option<Ordering>,
+}
+
+impl<L, R, F> MergeJoinLeftExcl<L, R, F> where
+    L: Iterator,
+    R: Iterator,
+{
+    /// Create a `MergeJoinLeftExcl` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI, cmp: F) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              R: Iterator<Item=RI::Item>,
+              RI: IntoIterator<IntoIter=R>,
+              F: FnMut(&L::Item, &R::Item) -> Ordering
+    {
+        MergeJoinLeftExcl {
+            left: left.into_iter().peekable(),
+            right: right.into_iter().peekable(),
+            cmp: cmp,
+            fused: None,
+        }
+    }
+}
+
+impl<L, R, F> Iterator for MergeJoinLeftExcl<L, R, F> 
+    where L: Iterator,
+          R: Iterator,
+          F: FnMut(&L::Item, &R::Item) -> Ordering
+{
+    type Item = L::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let ord = match self.fused {
+                Some(o) => o,
+                None => match (self.left.peek(), self.right.peek()) {
+                    (Some(l), Some(r)) => (self.cmp)(l, r),
+                    (Some(_), None) => {
+                        self.fused = Some(Ordering::Less);
+                        Ordering::Less
+                    }
+                    _ => return None,
+                }
+            };
+
+            match ord {
+                Ordering::Less => return self.left.next(),
+                Ordering::Greater => {self.right.next();},
+                Ordering::Equal => {
+                    self.left.next();
+                    self.right.next();
+                }
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that [left outer
+/// joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Left_outer_join) the two base iterators in
+/// ascending order. The resulting iterator contains all the records from the left input iterator,
+/// even if they do not match the right input iterator.
+///
+/// The both base iterators must be sorted (ascending) and unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by) them, if necessary) to produce the correct results.
+///
+/// Iterator element type is [`EitherOrBoth<L::Item, R::Item>`](enum.EitherOrBoth.html).
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct MergeJoinLeftOuter<L, R, F> where
+    L: Iterator,
+    R: Iterator,
+{
+    left: Peekable<L>,
+    right: Peekable<R>,
+    cmp: F,
+    fused: Option<Ordering>,
+}
+
+impl<L, R, F> MergeJoinLeftOuter<L, R, F> where
+    L: Iterator,
+    R: Iterator,
+{
+    /// Create a `MergeJoinLeftOuter` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI, cmp: F) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              R: Iterator<Item=RI::Item>,
+              RI: IntoIterator<IntoIter=R>,
+              F: FnMut(&L::Item, &R::Item) -> Ordering
+    {
+        MergeJoinLeftOuter {
+            left: left.into_iter().peekable(),
+            right: right.into_iter().peekable(),
+            cmp: cmp,
+            fused: None,
+        }
+    }
+}
+
+impl<L, R, F> Iterator for MergeJoinLeftOuter<L, R, F>
+    where L: Iterator,
+          R: Iterator,
+          F: FnMut(&L::Item, &R::Item) -> Ordering
+{
+    type Item = EitherOrBoth<L::Item, R::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let ord = match self.fused {
+                Some(o) => o,
+                None => match (self.left.peek(), self.right.peek()) {
+                    (Some(l), Some(r)) => (self.cmp)(l, r),
+                    (Some(_), None) => {
+                        self.fused = Some(Ordering::Less);
+                        Ordering::Less
+                    }
+                    _ => return None,
+                }
+            };
+
+            match ord {
+                Ordering::Less => match self.left.next() {
+                    Some(l) => return Some(Left(l)),
+                    None => return None,
+                },
+                Ordering::Greater => {self.right.next();},
+                Ordering::Equal => match (self.left.next(), self.right.next()) {
+                    (Some(l), Some(r)) => return Some(Both(l, r)),
+                    _ => return None,
+                }
+            }
+        }
+    }
+}
+
+/// An iterator adaptor that [full outer
+/// joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Full_outer_join) the two base iterators in
+/// ascending order. The resulting iterator contains all the records from the both input iterators.
+///
+/// The both base iterators must be sorted (ascending) and unique on the join key (e.g. by
+/// [grouping](trait.Itertools.html#method.group_by) them, if necessary) to produce the correct results.
+///
+/// Iterator element type is [`EitherOrBoth<L::Item, R::Item>`](enum.EitherOrBoth.html).
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct MergeJoinFullOuter<L, R, F> where
+    L: Iterator,
+    R: Iterator,
+{
+    left: Peekable<L>,
+    right: Peekable<R>,
+    cmp: F,
+    fused: Option<Ordering>,
+}
+
+impl<L, R, F> MergeJoinFullOuter<L, R, F> where
+    L: Iterator,
+    R: Iterator,
+{
+    /// Create a `MergeJoinFullOuter` iterator.
+    pub fn new<LI, RI>(left: LI, right: RI, cmp: F) -> Self
+        where L: Iterator<Item=LI::Item>,
+              LI: IntoIterator<IntoIter=L>,
+              R: Iterator<Item=RI::Item>,
+              RI: IntoIterator<IntoIter=R>,
+              F: FnMut(&L::Item, &R::Item) -> Ordering
+    {
+        MergeJoinFullOuter {
+            left: left.into_iter().peekable(),
+            right: right.into_iter().peekable(),
+            cmp: cmp,
+            fused: None,
+        }
+    }
+}
+
+impl<L, R, F> Iterator for MergeJoinFullOuter<L, R, F>
+    where L: Iterator,
+          R: Iterator,
+          F: FnMut(&L::Item, &R::Item) -> Ordering
+{
+    type Item = EitherOrBoth<L::Item, R::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let ord = match self.fused {
+                Some(o) => o,
+                None => match (self.left.peek(), self.right.peek()) {
+                    (Some(l), Some(r)) => (self.cmp)(l, r),
+                    (Some(_), None) => {
+                        self.fused = Some(Ordering::Less);
+                        Ordering::Less
+                    }
+                    (None, Some(_)) => {
+                        self.fused = Some(Ordering::Greater);
+                        Ordering::Greater
+                    }
+                    _ => return None,
+                }
+            };
+
+            match ord {
+                Ordering::Less => match self.left.next() {
+                    Some(l) => return Some(Left(l)),
+                    None => return None,
+                },
+                Ordering::Greater => match self.right.next() {
+                    Some(r) => return Some(Right(r)),
+                    None => return None,
+                },
+                Ordering::Equal => match (self.left.next(), self.right.next()) {
+                    (Some(l), Some(r)) => return Some(Both(l, r)),
+                    _ => return None,
+                }
+            }
+        }
+    }
+}

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -77,7 +77,7 @@ impl<T, U> ExactSizeIterator for ZipLongest<T, U> where
 {}
 
 
-/// A value yielded by `ZipLongest`.
+/// A value yielded by `ZipLongest`, `merge_join` and `hash_join` outer iterators.
 /// Contains one or two values, depending on which of the input iterators are exhausted.
 ///
 /// See [*.zip_longest()*](trait.Itertools.html#method.zip_longest) for more information.
@@ -85,10 +85,8 @@ impl<T, U> ExactSizeIterator for ZipLongest<T, U> where
 pub enum EitherOrBoth<A, B> {
     /// Neither input iterator is exhausted yet, yielding two values.
     Both(A, B),
-    /// The parameter iterator of `.zip_longest()` is exhausted,
-    /// only yielding a value from the `self` iterator.
+    /// The parameter iterator is exhausted, only yielding a value from the `self` iterator.
     Left(A),
-    /// The `self` iterator of `.zip_longest()` is exhausted,
-    /// only yielding a value from the parameter iterator.
+    /// The `self` iterator is exhausted, only yielding a value from the parameter iterator.
     Right(B),
 }

--- a/tests/hash_join.rs
+++ b/tests/hash_join.rs
@@ -1,6 +1,5 @@
 extern crate itertools;
 
-use std::rc::Rc;
 use std::collections::HashSet;
 use itertools::Itertools;
 use itertools::EitherOrBoth::{Both, Left, Right};
@@ -10,7 +9,7 @@ fn inner_fused() {
     let a = (0..3).zip(0..3);
     let b = (2..5).zip(2..5);
     let mut it = a.hash_join_inner(b);
-    assert_eq!(it.next(), Some((2, Rc::new(2))));
+    assert_eq!(it.next(), Some((2, 2)));
     assert_eq!(it.next(), None);
 }
 #[test]
@@ -18,7 +17,7 @@ fn inner_fused_inv() {
     let a = (2..5).zip(2..5);
     let b = (0..3).zip(0..3);
     let mut it = a.hash_join_inner(b);
-    assert_eq!(it.next(), Some((2, Rc::new(2))));
+    assert_eq!(it.next(), Some((2, 2)));
     assert_eq!(it.next(), None);
 }
 
@@ -49,7 +48,7 @@ fn left_outer_fused() {
     let mut it = a.hash_join_left_outer(b);
     assert_eq!(it.next(), Some(Left(0)));
     assert_eq!(it.next(), Some(Left(1)));
-    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    assert_eq!(it.next(), Some(Both(2, 2)));
     assert_eq!(it.next(), None);
 }
 #[test]
@@ -57,7 +56,7 @@ fn left_outer_fused_inv() {
     let a = (2..5).zip(2..5);
     let b = (0..3).zip(0..3);
     let mut it = a.hash_join_left_outer(b);
-    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    assert_eq!(it.next(), Some(Both(2, 2)));
     assert_eq!(it.next(), Some(Left(3)));
     assert_eq!(it.next(), Some(Left(4)));
     assert_eq!(it.next(), None);
@@ -68,9 +67,9 @@ fn right_excl_fused() {
     let a = (0..3).zip(0..3);
     let b = (2..5).zip(2..5);
     let mut it = a.hash_join_right_excl(b);
-    let right_values: HashSet<Rc<u64>> = it.by_ref().take(2).collect();
-    assert!(right_values.contains(&Rc::new(3)));
-    assert!(right_values.contains(&Rc::new(4)));
+    let right_values: HashSet<u64> = it.by_ref().take(2).collect();
+    assert!(right_values.contains(&3));
+    assert!(right_values.contains(&4));
     assert_eq!(it.next(), None);
 }
 #[test]
@@ -78,9 +77,9 @@ fn right_excl_fused_inv() {
     let a = (2..5).zip(2..5);
     let b = (0..3).zip(0..3);
     let mut it = a.hash_join_right_excl(b);
-    let right_values: HashSet<Rc<u64>> = it.by_ref().take(2).collect();
-    assert!(right_values.contains(&Rc::new(0)));
-    assert!(right_values.contains(&Rc::new(1)));
+    let right_values: HashSet<u64> = it.by_ref().take(2).collect();
+    assert!(right_values.contains(&0));
+    assert!(right_values.contains(&1));
     assert_eq!(it.next(), None);
 }
 
@@ -89,16 +88,16 @@ fn right_outer_fused() {
     let a = (0..3).zip(0..3);
     let b = (2..5).zip(2..5);
     let mut it = a.hash_join_right_outer(b);
-    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
-    let right_values: HashSet<Rc<u64>> = it.by_ref()
+    assert_eq!(it.next(), Some(Both(2, 2)));
+    let right_values: HashSet<u64> = it.by_ref()
         .take(2)
         .map(|e| match e {
                     Right(r) => return r,
                     _ => panic!("Expected Right variant"),
              })
         .collect();
-    assert!(right_values.contains(&Rc::new(3)));
-    assert!(right_values.contains(&Rc::new(4)));
+    assert!(right_values.contains(&3));
+    assert!(right_values.contains(&4));
     assert_eq!(it.next(), None);
 }
 #[test]
@@ -106,16 +105,16 @@ fn right_outer_fused_inv() {
     let a = (2..5).zip(2..5);
     let b = (0..3).zip(0..3);
     let mut it = a.hash_join_right_outer(b);
-    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
-    let right_values: HashSet<Rc<u64>> = it.by_ref()
+    assert_eq!(it.next(), Some(Both(2, 2)));
+    let right_values: HashSet<u64> = it.by_ref()
         .take(2)
         .map(|e| match e {
                     Right(r) => return r,
                     _ => panic!("Expected Right variant"),
              })
         .collect();
-    assert!(right_values.contains(&Rc::new(0)));
-    assert!(right_values.contains(&Rc::new(1)));
+    assert!(right_values.contains(&0));
+    assert!(right_values.contains(&1));
     assert_eq!(it.next(), None);
 }
 
@@ -126,16 +125,16 @@ fn full_outer_fused() {
     let mut it = a.hash_join_full_outer(b);
     assert_eq!(it.next(), Some(Left(0)));
     assert_eq!(it.next(), Some(Left(1)));
-    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
-    let right_values: HashSet<Rc<u64>> = it.by_ref()
+    assert_eq!(it.next(), Some(Both(2, 2)));
+    let right_values: HashSet<u64> = it.by_ref()
         .take(2)
         .map(|e| match e {
                     Right(r) => return r,
                     _ => panic!("Expected Right variant"),
              })
         .collect();
-    assert!(right_values.contains(&Rc::new(3)));
-    assert!(right_values.contains(&Rc::new(4)));
+    assert!(right_values.contains(&3));
+    assert!(right_values.contains(&4));
     assert_eq!(it.next(), None);
 }
 
@@ -144,17 +143,17 @@ fn full_outer_fused_inv() {
     let a = (2..5).zip(2..5);
     let b = (0..3).zip(0..3);
     let mut it = a.hash_join_full_outer(b);
-    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    assert_eq!(it.next(), Some(Both(2, 2)));
     assert_eq!(it.next(), Some(Left(3)));
     assert_eq!(it.next(), Some(Left(4)));
-    let right_values: HashSet<Rc<u64>> = it.by_ref()
+    let right_values: HashSet<u64> = it.by_ref()
         .take(2)
         .map(|e| match e {
                     Right(r) => return r,
                     _ => panic!("Expected Right variant"),
              })
         .collect();
-    assert!(right_values.contains(&Rc::new(0)));
-    assert!(right_values.contains(&Rc::new(1)));
+    assert!(right_values.contains(&0));
+    assert!(right_values.contains(&1));
     assert_eq!(it.next(), None);
 }

--- a/tests/hash_join.rs
+++ b/tests/hash_join.rs
@@ -1,0 +1,160 @@
+extern crate itertools;
+
+use std::rc::Rc;
+use std::collections::HashSet;
+use itertools::Itertools;
+use itertools::EitherOrBoth::{Both, Left, Right};
+
+#[test]
+fn inner_fused() {
+    let a = (0..3).zip(0..3);
+    let b = (2..5).zip(2..5);
+    let mut it = a.hash_join_inner(b);
+    assert_eq!(it.next(), Some((2, Rc::new(2))));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn inner_fused_inv() {
+    let a = (2..5).zip(2..5);
+    let b = (0..3).zip(0..3);
+    let mut it = a.hash_join_inner(b);
+    assert_eq!(it.next(), Some((2, Rc::new(2))));
+    assert_eq!(it.next(), None);
+}
+
+
+#[test]
+fn left_excl_fused() {
+    let a = (0..3).zip(0..3);
+    let b = (2..5).zip(2..5);
+    let mut it = a.hash_join_left_excl(b);
+    assert_eq!(it.next(), Some(0));
+    assert_eq!(it.next(), Some(1));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn left_excl_fused_inv() {
+    let a = (2..5).zip(2..5);
+    let b = (0..3).zip(0..3);
+    let mut it = a.hash_join_left_excl(b);
+    assert_eq!(it.next(), Some(3));
+    assert_eq!(it.next(), Some(4));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn left_outer_fused() {
+    let a = (0..3).zip(0..3);
+    let b = (2..5).zip(2..5);
+    let mut it = a.hash_join_left_outer(b);
+    assert_eq!(it.next(), Some(Left(0)));
+    assert_eq!(it.next(), Some(Left(1)));
+    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn left_outer_fused_inv() {
+    let a = (2..5).zip(2..5);
+    let b = (0..3).zip(0..3);
+    let mut it = a.hash_join_left_outer(b);
+    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    assert_eq!(it.next(), Some(Left(3)));
+    assert_eq!(it.next(), Some(Left(4)));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn right_excl_fused() {
+    let a = (0..3).zip(0..3);
+    let b = (2..5).zip(2..5);
+    let mut it = a.hash_join_right_excl(b);
+    let right_values: HashSet<Rc<u64>> = it.by_ref().take(2).collect();
+    assert!(right_values.contains(&Rc::new(3)));
+    assert!(right_values.contains(&Rc::new(4)));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn right_excl_fused_inv() {
+    let a = (2..5).zip(2..5);
+    let b = (0..3).zip(0..3);
+    let mut it = a.hash_join_right_excl(b);
+    let right_values: HashSet<Rc<u64>> = it.by_ref().take(2).collect();
+    assert!(right_values.contains(&Rc::new(0)));
+    assert!(right_values.contains(&Rc::new(1)));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn right_outer_fused() {
+    let a = (0..3).zip(0..3);
+    let b = (2..5).zip(2..5);
+    let mut it = a.hash_join_right_outer(b);
+    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    let right_values: HashSet<Rc<u64>> = it.by_ref()
+        .take(2)
+        .map(|e| match e {
+                    Right(r) => return r,
+                    _ => panic!("Expected Right variant"),
+             })
+        .collect();
+    assert!(right_values.contains(&Rc::new(3)));
+    assert!(right_values.contains(&Rc::new(4)));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn right_outer_fused_inv() {
+    let a = (2..5).zip(2..5);
+    let b = (0..3).zip(0..3);
+    let mut it = a.hash_join_right_outer(b);
+    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    let right_values: HashSet<Rc<u64>> = it.by_ref()
+        .take(2)
+        .map(|e| match e {
+                    Right(r) => return r,
+                    _ => panic!("Expected Right variant"),
+             })
+        .collect();
+    assert!(right_values.contains(&Rc::new(0)));
+    assert!(right_values.contains(&Rc::new(1)));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn full_outer_fused() {
+    let a = (0..3).zip(0..3);
+    let b = (2..5).zip(2..5);
+    let mut it = a.hash_join_full_outer(b);
+    assert_eq!(it.next(), Some(Left(0)));
+    assert_eq!(it.next(), Some(Left(1)));
+    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    let right_values: HashSet<Rc<u64>> = it.by_ref()
+        .take(2)
+        .map(|e| match e {
+                    Right(r) => return r,
+                    _ => panic!("Expected Right variant"),
+             })
+        .collect();
+    assert!(right_values.contains(&Rc::new(3)));
+    assert!(right_values.contains(&Rc::new(4)));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn full_outer_fused_inv() {
+    let a = (2..5).zip(2..5);
+    let b = (0..3).zip(0..3);
+    let mut it = a.hash_join_full_outer(b);
+    assert_eq!(it.next(), Some(Both(2, Rc::new(2))));
+    assert_eq!(it.next(), Some(Left(3)));
+    assert_eq!(it.next(), Some(Left(4)));
+    let right_values: HashSet<Rc<u64>> = it.by_ref()
+        .take(2)
+        .map(|e| match e {
+                    Right(r) => return r,
+                    _ => panic!("Expected Right variant"),
+             })
+        .collect();
+    assert!(right_values.contains(&Rc::new(0)));
+    assert!(right_values.contains(&Rc::new(1)));
+    assert_eq!(it.next(), None);
+}

--- a/tests/merge_join.rs
+++ b/tests/merge_join.rs
@@ -1,0 +1,87 @@
+extern crate itertools;
+
+use itertools::Itertools;
+use itertools::EitherOrBoth::{Both, Left, Right};
+
+#[test]
+fn inner_fused() {
+    let a = 0..3;
+    let b = 2..5;
+    let mut it = a.merge_join_inner_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some((2, 2)));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn inner_fused_inv() {
+    let a = 2..5;
+    let b = 0..3;
+    let mut it = a.merge_join_inner_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some((2, 2)));
+    assert_eq!(it.next(), None);
+}
+
+
+#[test]
+fn left_excl_fused() {
+    let a = 0..3;
+    let b = 2..5;
+    let mut it = a.merge_join_left_excl_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some(0));
+    assert_eq!(it.next(), Some(1));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn left_excl_fused_inv() {
+    let a = 2..5;
+    let b = 0..3;
+    let mut it = a.merge_join_left_excl_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some(3));
+    assert_eq!(it.next(), Some(4));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn left_outer_fused() {
+    let a = 0..3;
+    let b = 2..5;
+    let mut it = a.merge_join_left_outer_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some(Left(0)));
+    assert_eq!(it.next(), Some(Left(1)));
+    assert_eq!(it.next(), Some(Both(2, 2)));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn left_outer_fused_inv() {
+    let a = 2..5;
+    let b = 0..3;
+    let mut it = a.merge_join_left_outer_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some(Both(2, 2)));
+    assert_eq!(it.next(), Some(Left(3)));
+    assert_eq!(it.next(), Some(Left(4)));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn full_outer_fused() {
+    let a = 0..3;
+    let b = 2..5;
+    let mut it = a.merge_join_full_outer_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some(Left(0)));
+    assert_eq!(it.next(), Some(Left(1)));
+    assert_eq!(it.next(), Some(Both(2, 2)));
+    assert_eq!(it.next(), Some(Right(3)));
+    assert_eq!(it.next(), Some(Right(4)));
+    assert_eq!(it.next(), None);
+}
+#[test]
+fn full_outer_fused_inv() {
+    let a = 2..5;
+    let b = 0..3;
+    let mut it = a.merge_join_full_outer_by(b, |x, y| Ord::cmp(&x, &y));
+    assert_eq!(it.next(), Some(Right(0)));
+    assert_eq!(it.next(), Some(Right(1)));
+    assert_eq!(it.next(), Some(Both(2, 2)));
+    assert_eq!(it.next(), Some(Left(3)));
+    assert_eq!(it.next(), Some(Left(4)));
+    assert_eq!(it.next(), None);
+}


### PR DESCRIPTION
Hi,

This pull request contains the extension of the rust-itertools with SQL-like join adaptors. It covers all the standard SQL joins (inner + outer) as well as non-standard (but very useful) exclusive joins, which are well explained in docs.
Since they are all iterator adaptors, I thought  it would be better to add them into rust-itertools rather than creating a standalone library/project.

The adaptors are designed in a generic way, therefore they are very flexible.

There are two join strategies provided: **hash_join** and **merge_join**.

**hash_join**: allows join of non-sorted iterators, but requires the smaller one to be collectable into hash map (the other one can be arbitrarily long). This condition is usually satisfied, therefore this is the preferred strategy for its efficiency (no need to sort anything).

**merge_join**: allows join of sorted, arbitrarily large iterators. The user is responsible for providing a function comparing the left and the right iterator elements. As distinct from `merge_by` adaptor, the function must return `Ordering`, because we are interested also in the `Greater` variant.

All the objects are (hopefully) well documented and there are also tests for each adaptor.

The last point - this is my first pull request, therefore I apologize in advance if I missed something in the etiquette :)

Thank you for your consideration.
Regards,
milancio42