### PR TITLE
Add `run_length` adaptor

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -1219,3 +1219,45 @@ pub fn unique<I>(iter: I) -> Unique<I>
         }
     }
 }
+
+/// An iterator adapter that yields the run length of an element and its value
+///
+/// Iterator element type is `(usize, I::Item)`.
+///
+/// See [*.run_length()*](trait.Itertools.html#method.run_length) for more information.
+pub struct RunLength<I>
+    where I: Iterator
+{
+    iter: Peekable<I>
+}
+
+impl<I> RunLength<I>
+    where I: Iterator
+{
+    /// Create a new `RunLength` iterator.
+    pub fn new(i: I) -> RunLength<I> {
+        RunLength { iter: i.peekable() }
+    }
+}
+
+impl<I, T> Iterator for RunLength<I>
+    where I: Iterator<Item=T>, T: Eq
+{
+    type Item = (usize, I::Item);
+
+    fn next(&mut self) -> Option<(usize, I::Item)> {
+        let current = match self.iter.next() {
+            Some(current) => current,
+            None => return None,
+        };
+
+        let mut length = 1;
+
+        while self.iter.peek() == Some(&current) {
+            length += 1;
+            self.iter.next();
+        }
+
+        Some((length, current))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub use adaptors::{
     Combinations,
     Unique,
     UniqueBy,
+    RunLength,
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
@@ -1235,6 +1236,22 @@ pub trait Itertools : Iterator {
               F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
         self.sorted_by(cmp)
+    }
+
+    /// Return an iterator adaptor that yields the run length of an element and its value
+    ///
+    /// Iterator element type is `(usize, Self::Item)`
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let it = "abbcccd".chars().run_length();
+    /// itertools::assert_equal(it, vec![(1, 'a'), (2, 'b'), (3, 'c'), (1, 'd')]);
+    /// ```
+    fn run_length(self) -> RunLength<Self>
+        where Self: Sized, Self::Item: Eq
+    {
+        RunLength::new(self)
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -793,3 +793,10 @@ fn chunks_lazy() {
         }
     }
 }
+
+#[test]
+fn run_length() {
+    let it = "abbcccd".chars().run_length();
+    it::assert_equal(it, vec![(1, 'a'), (2, 'b'), (3, 'c'), (1, 'd')]);
+    assert_eq!(None, "".chars().run_length().next());
+}


### PR DESCRIPTION
Hi,

this commit implements an iterator adaptor that yields the run length of an element and its value