### PR TITLE
Add itertools::func.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,10 @@ How to use in your crate:
 Recent Changes
 --------------
 
+- UNRELEASED
+
+  - Add func() for repeatedly calling a function.
+
 - 0.4.5
 
   - Add .flatten()

--- a/src/fn_iter.rs
+++ b/src/fn_iter.rs
@@ -4,6 +4,27 @@ pub struct FnIter<F>(F);
 /// Iterate over a function.
 ///
 /// The returned Iterator calls the passed function on each call to next.
+///
+/// Example:
+///
+/// ```
+/// // Generate the fibonacci sequence (no recursion).
+/// let fib = itertools::func({
+///     let mut a = 0;
+///     let mut b = 1;
+///     move || {
+///         let ret = a;
+///         let next = a + b;
+///         a = b;
+///         b = next;
+///         Some(ret)
+///     }
+/// });
+///
+/// itertools::assert_equal(fib.take(10), vec![0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
+/// ```
+///
+/// 
 pub fn func<T, F>(f: F) -> FnIter<F>
     where F: FnMut() -> Option<T>
 {

--- a/src/fn_iter.rs
+++ b/src/fn_iter.rs
@@ -1,0 +1,20 @@
+/// An iterator that yields values returned by a function.
+pub struct FnIter<F>(F);
+
+/// Iterate over a function.
+///
+/// The returned Iterator calls the passed function on each call to next.
+pub fn func<T, F>(f: F) -> FnIter<F>
+    where F: FnMut() -> Option<T>
+{
+    FnIter(f)
+}
+
+impl<T, F> Iterator for FnIter<F>
+    where F: FnMut() -> Option<T>
+{
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        (self.0)()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub use adaptors::{
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
 pub use format::Format;
+pub use fn_iter::{FnIter, func};
 pub use groupbylazy::{ChunksLazy, Chunk, Chunks, GroupByLazy, Group, Groups};
 pub use intersperse::Intersperse;
 pub use islice::{ISlice};
@@ -87,6 +88,7 @@ pub use ziptrusted::{ZipTrusted, TrustedIterator};
 pub use zipslices::ZipSlices;
 mod adaptors;
 mod format;
+mod fn_iter;
 mod groupbylazy;
 mod intersperse;
 mod islice;

--- a/tests/fn_iter.rs
+++ b/tests/fn_iter.rs
@@ -1,0 +1,11 @@
+extern crate itertools;
+
+#[test]
+fn test_fn_iter() {
+    let nums = itertools::func({
+        let mut counter = 0;
+        move || { counter += 1; Some(counter) }
+    });
+
+    itertools::assert_equal(nums.take(10), 1..11);
+}


### PR DESCRIPTION
This is effectively a shortcut for `iter::repeat(()).map(|_| something)`
but less ugly.