### PR TITLE
Added `diff.rs` module with `diff` and `copy_on_diff` - for efficiently "diff"ing and caching non-`Clone` iterators.

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -176,6 +176,13 @@ impl<I> PutBack<I> where
         PutBack{top: None, iter: it}
     }
 
+    /// Create a `PutBack` along with the `value` to put back.
+    #[inline]
+    pub fn value(value: I::Item, it: I) -> Self
+    {
+        PutBack{top: Some(value), iter: it}
+    }
+
     /// Put back a single value to the front of the iterator.
     ///
     /// If a value is already in the put back slot, it is overwritten.

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -178,9 +178,17 @@ impl<I> PutBack<I> where
 
     /// Create a `PutBack` along with the `value` to put back.
     #[inline]
-    pub fn value(value: I::Item, it: I) -> Self
+    pub fn with_value(value: I::Item, it: I) -> Self
     {
         PutBack{top: Some(value), iter: it}
+    }
+
+    /// Split the `PutBack` into its parts.
+    #[inline]
+    pub fn into_parts(self) -> (Option<I::Item>, I)
+    {
+        let PutBack{top, iter} = self;
+        (top, iter)
     }
 
     /// Put back a single value to the front of the iterator.

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -82,16 +82,16 @@ fn diff_internal<I, J, F>(i: I, j: J, is_diff: F) -> Option<Diff<I::IntoIter, J:
     let mut idx = 0;
     while let Some(i_elem) = i.next() {
         match j.next() {
-            None => return Some(Diff::Shorter(idx, PutBack::value(i_elem, i))),
+            None => return Some(Diff::Shorter(idx, PutBack::with_value(i_elem, i))),
             Some(j_elem) => if is_diff(&i_elem, &j_elem) {
-                let remaining_i = PutBack::value(i_elem, i);
-                let remaining_j = PutBack::value(j_elem, j);
+                let remaining_i = PutBack::with_value(i_elem, i);
+                let remaining_j = PutBack::with_value(j_elem, j);
                 return Some(Diff::FirstMismatch(idx, remaining_i, remaining_j));
             },
         }
         idx += 1;
     }
-    j.next().map(|j_elem| Diff::Longer(idx, PutBack::value(j_elem, j)))
+    j.next().map(|j_elem| Diff::Longer(idx, PutBack::with_value(j_elem, j)))
 }
 
 /// Returns `Cow::Borrowed` `collection` if `collection` contains the same elements as yielded by

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,17 +1,13 @@
 //! "Diff"ing iterators for caching elements to sequential collections without requiring the new
 //! elements' iterator to be `Clone`.
 //!
-//! - [**Diff**](./enum.Diff.html) (produced by the [**diff**](./fn.diff.html) and
-//! [**diff_by_ref**](./fn.diff_by_ref.html) functions) describes the difference between two
-//! non-`Clone` iterators `a` and `b` after breaking ASAP from a comparison with enough data to
-//! update `a`'s collection.
-//! - [**copy_on_diff**](./fn.copy_on_diff.html) is an application of [**diff**] that compares two
-//! iterators `a` and `b`, borrowing the source of `a` if they are the same or creating a new owned
-//! collection with `b`'s elements if they are different.
+//! - [**Diff**](./enum.Diff.html) (produced by the [**diff_with**](./fn.diff_with.html) function)
+//! describes the difference between two non-`Clone` iterators `I` and `J` after breaking ASAP from
+//! a lock-step comparison.
 
 use adaptors::PutBack;
 
-/// A type returned by the [`diff`](./fn.diff.html) function.
+/// A type returned by the [`diff_with`](./fn.diff_with.html) function.
 ///
 /// `Diff` represents the way in which the elements yielded by the iterator `I` differ to some
 /// iterator `J`.

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,9 +1,10 @@
 //! "Diff"ing iterators for caching elements to sequential collections without requiring the new
 //! elements' iterator to be `Clone`.
 //!
-//! - [**Diff**](./enum.Diff.html) (produced by the [**diff**](./fn.diff.html) function) describes
-//! the difference between two non-`Clone` iterators `a` and `b` after breaking ASAP from a
-//! comparison with enough data to update `a`'s collection.
+//! - [**Diff**](./enum.Diff.html) (produced by the [**diff**](./fn.diff.html) and
+//! [**diff_by_ref**](./fn.diff_by_ref.html) functions) describes the difference between two
+//! non-`Clone` iterators `a` and `b` after breaking ASAP from a comparison with enough data to
+//! update `a`'s collection.
 //! - [**copy_on_diff**](./fn.copy_on_diff.html) is an application of [**diff**] that compares two
 //! iterators `a` and `b`, borrowing the source of `a` if they are the same or creating a new owned
 //! collection with `b`'s elements if they are different.
@@ -20,12 +21,12 @@ pub enum Diff<I, J>
     where I: Iterator,
           J: Iterator,
 {
-    /// The index of the first non-matching element along with the iterator's remaining elements
-    /// starting with the first mis-matched element.
+    /// The index of the first non-matching element along with both iterator's remaining elements
+    /// starting with the first mis-match.
     FirstMismatch(usize, PutBack<I>, PutBack<J>),
-    /// The total number of elements that were in the iterator.
+    /// The total number of elements that were in `J` along with the remaining elements of `I`.
     Shorter(usize, PutBack<I>),
-    /// The remaining elements of the iterator.
+    /// The total number of elements that were in `I` along with the remaining elements of `J`.
     Longer(usize, PutBack<J>),
 }
 
@@ -49,7 +50,7 @@ pub fn diff<I, J>(i: I, j: J) -> Option<Diff<I::IntoIter, J::IntoIter>>
     diff_internal(i, j, |ie, je| ie != je)
 }
 
-/// Similar to [`diff`](./fn.diff), however expects `i` to yield references to its elements.
+/// Similar to [`diff`](./fn.diff.html), however expects `i` to yield references to its elements.
 ///
 /// This function is useful for caching some iterator `j` in some sequential collection without
 /// requiring `j` to be `Clone` in order to compare it to the collection before determining if the

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -14,57 +14,83 @@ use std::iter::FromIterator;
 
 /// A type returned by the [`diff`](./fn.diff.html) function.
 ///
-/// `Diff` represents the way in which the elements (of type `E`) yielded by the iterator `I`
-/// differ to some other iterator yielding borrowed elements of the same type.
-///
-/// `I` is some `Iterator` yielding elements of type `E`.
-pub enum Diff<I>
+/// `Diff` represents the way in which the elements yielded by the iterator `I` differ to some
+/// iterator `J`.
+pub enum Diff<I, J>
     where I: Iterator,
+          J: Iterator,
 {
     /// The index of the first non-matching element along with the iterator's remaining elements
     /// starting with the first mis-matched element.
-    FirstMismatch(usize, PutBack<I>),
-    /// The remaining elements of the iterator.
-    Longer(PutBack<I>),
+    FirstMismatch(usize, PutBack<I>, PutBack<J>),
     /// The total number of elements that were in the iterator.
-    Shorter(usize),
+    Shorter(usize, PutBack<I>),
+    /// The remaining elements of the iterator.
+    Longer(usize, PutBack<J>),
 }
 
-/// Compares every element yielded by both elems and new_elems in lock-step and returns a `Diff`
-/// which describes how `j` differs from `i`.
+/// Compares every element yielded by both `i` and `j` in lock-step and returns a `Diff` which
+/// describes how `j` differs from `i`.
+///
+/// If the number of elements yielded by `j` is less than the number of elements yielded by `i`,
+/// the number of `j` elements yielded will be returned along with `i`'s remaining elements as
+/// `Diff::Shorter`.
+///
+/// If the two elements of a step differ, the index of those elements along with the remaining
+/// elements of both `i` and `j` are returned as `Diff::FirstMismatch`.
+///
+/// If `i` becomes exhausted before `j` becomes exhausted, the number of elements in `i` along with
+/// the remaining `j` elements will be returned as `Diff::Longer`.
+pub fn diff<I, J>(i: I, j: J) -> Option<Diff<I::IntoIter, J::IntoIter>>
+    where I: IntoIterator,
+          J: IntoIterator,
+          I::Item: PartialEq<J::Item>,
+{
+    diff_internal(i, j, |ie, je| ie != je)
+}
+
+/// Similar to [`diff`](./fn.diff), however expects `i` to yield references to its elements.
 ///
 /// This function is useful for caching some iterator `j` in some sequential collection without
 /// requiring `j` to be `Clone` in order to compare it to the collection before determining if the
-/// collection needs to be updated. The returned function returns as soon as a difference is found,
+/// collection needs to be updated. The function returns as soon as a difference is found,
 /// producing a `Diff` that provides the data necessary to update the collection without ever
 /// requiring `J` to be `Clone`. This allows for efficiently caching iterators like `Map` or
 /// `Filter` that do not implement `Clone`.
 ///
-/// If the number of elements yielded by `j` is less than the number of elements yielded by `i`,
-/// the number of `j` elements yielded will be returned as `Diff::Shorter`.
-///
-/// If the two elements of a step differ, the index of those elements along with the remaining
-/// elements of `j` are returned as `Diff::FirstMismatch`.
-///
-/// If `i` becomes exhausted before `j` becomes exhausted, the remaining `j` elements will be
-/// returned as `Diff::Longer`.
-///
 /// See [`copy_on_diff`](./fn.copy_on_diff.html) for an application of `diff`.
-pub fn diff<'a, I, J>(i: I, j: J) -> Option<Diff<J::IntoIter>>
+pub fn diff_by_ref<'a, I, J>(i: I, j: J) -> Option<Diff<I::IntoIter, J::IntoIter>>
     where I: IntoIterator<Item=&'a J::Item>,
           J: IntoIterator,
           J::Item: PartialEq + 'a,
 {
+    diff_internal(i, j, |ie, je| *ie != je)
+}
+
+// Compares every element yielded by both `i` and `j`  with the given `is_diff` function in
+// lock-step.
+//
+// Returns a `Diff` which describes how `j` differs from `i`.
+fn diff_internal<I, J, F>(i: I, j: J, is_diff: F) -> Option<Diff<I::IntoIter, J::IntoIter>>
+    where I: IntoIterator,
+          J: IntoIterator,
+          F: Fn(&I::Item, &J::Item) -> bool,
+{
+    let mut i = i.into_iter();
     let mut j = j.into_iter();
-    for (idx, i_elem) in i.into_iter().enumerate() {
+    let mut idx = 0;
+    while let Some(i_elem) = i.next() {
         match j.next() {
-            None => return Some(Diff::Shorter(idx)),
-            Some(j_elem) => if *i_elem != j_elem {
-                return Some(Diff::FirstMismatch(idx, PutBack::value(j_elem, j)));
+            None => return Some(Diff::Shorter(idx, PutBack::value(i_elem, i))),
+            Some(j_elem) => if is_diff(&i_elem, &j_elem) {
+                let remaining_i = PutBack::value(i_elem, i);
+                let remaining_j = PutBack::value(j_elem, j);
+                return Some(Diff::FirstMismatch(idx, remaining_i, remaining_j));
             },
         }
+        idx += 1;
     }
-    j.next().map(|elem| Diff::Longer(PutBack::value(elem, j)))
+    j.next().map(|j_elem| Diff::Longer(idx, PutBack::value(j_elem, j)))
 }
 
 /// Returns `Cow::Borrowed` `collection` if `collection` contains the same elements as yielded by
@@ -113,13 +139,13 @@ pub fn copy_on_diff<'a, C, U, T: 'a>(collection: &'a C, update: U) -> Cow<'a, C>
           T: Clone + PartialEq,
 {
     let c_iter = collection.into_iter();
-    match diff(c_iter.clone(), update.into_iter()) {
+    match diff_by_ref(c_iter.clone(), update.into_iter()) {
         Some(diff) => match diff {
-            Diff::FirstMismatch(idx, mismatch) =>
+            Diff::FirstMismatch(idx, _, mismatch) =>
                 Cow::Owned(c_iter.take(idx).cloned().chain(mismatch).collect()),
-            Diff::Longer(remaining) =>
+            Diff::Longer(_, remaining) =>
                 Cow::Owned(c_iter.cloned().chain(remaining).collect()),
-            Diff::Shorter(num_update) =>
+            Diff::Shorter(num_update, _) =>
                 Cow::Owned(c_iter.cloned().take(num_update).collect()),
         },
         None => Cow::Borrowed(collection),

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -34,7 +34,7 @@ pub enum IterDiff<E, I> {
 /// requiring `b` to be `Clone` in order to compare it to the collection before determining if the
 /// collection needs to be updated. The returned function returns as soon as a difference is found,
 /// producing an `IterDiff` that provides the data necessary to update the collection without ever
-/// requiring `B` to be `Clone`. This allows for efficintly caching iterators like `Map` or
+/// requiring `B` to be `Clone`. This allows for efficiently caching iterators like `Map` or
 /// `Filter` that do not implement `Clone`.
 ///
 /// If the number of elements yielded by `b` is less than the number of elements yielded by `a`,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,121 @@
+//! "Diff"ing iterators for caching elements to sequential collections without requiring the new
+//! elements' iterator to be `Clone`.
+//!
+//! - [**IterDiff**](./enum.IterDiff.html) (produced by the [**iter_diff**](./fn.iter_diff.html)
+//! function) describes the difference between two non-`Clone` iterators `a` and `b` after breaking
+//! ASAP from a comparison with enough data to update `a`'s collection.
+//! - [**copy_on_diff**](./fn.copy_on_diff.html) is an application of [**iter_diff**] that compares
+//! two iterators `a` and `b`, borrowing the source of `a` if they are the same or creating a new
+//! owned collection with `b`'s elements if they are different.
+
+use std::borrow::{Cow, ToOwned};
+use std::iter;
+
+/// A type returned by the [`iter_diff`](./fn.iter_diff.html) function.
+///
+/// `IterDiff` represents the way in which the elements (of type `E`) yielded by the iterator `I`
+/// differ to some other iterator yielding borrowed elements of the same type.
+///
+/// `I` is some `Iterator` yielding elements of type `E`.
+pub enum IterDiff<E, I> {
+    /// The index of the first non-matching element along with the iterator's remaining elements
+    /// starting with the first mis-matched element.
+    FirstMismatch(usize, iter::Chain<iter::Once<E>, I>),
+    /// The remaining elements of the iterator.
+    Longer(iter::Chain<iter::Once<E>, I>),
+    /// The total number of elements that were in the iterator.
+    Shorter(usize),
+}
+
+/// Compares every element yielded by both elems and new_elems in lock-step and returns an
+/// `IterDiff` which describes how `b` differs from `a`.
+///
+/// This function is useful for caching some iterator `b` in some sequential collection without
+/// requiring `b` to be `Clone` in order to compare it to the collection before determining if the
+/// collection needs to be updated. The returned function returns as soon as a difference is found,
+/// producing an `IterDiff` that provides the data necessary to update the collection without ever
+/// requiring `B` to be `Clone`. This allows for efficintly caching iterators like `Map` or
+/// `Filter` that do not implement `Clone`.
+///
+/// If the number of elements yielded by `b` is less than the number of elements yielded by `a`,
+/// the number of `b` elements yielded will be returned as `IterDiff::Shorter`.
+///
+/// If the two elements of a step differ, the index of those elements along with the remaining
+/// elements of `b` are returned as `IterDiff::FirstMismatch`.
+///
+/// If `a` becomes exhausted before `b` becomes exhausted, the remaining `b` elements will be
+/// returned as `IterDiff::Longer`.
+///
+/// See [`copy_on_diff`](./fn.copy_on_diff.html) for an application of `iter_diff`.
+pub fn iter_diff<'a, A, B>(a: A, b: B) -> Option<IterDiff<B::Item, B::IntoIter>>
+    where A: IntoIterator<Item=&'a B::Item>,
+          B: IntoIterator,
+          B::Item: PartialEq + 'a,
+{
+    let mut b = b.into_iter();
+    for (i, a_elem) in a.into_iter().enumerate() {
+        match b.next() {
+            None => return Some(IterDiff::Shorter(i)),
+            Some(b_elem) => if *a_elem != b_elem {
+                return Some(IterDiff::FirstMismatch(i, iter::once(b_elem).chain(b)));
+            },
+        }
+    }
+    b.next().map(|elem| IterDiff::Longer(iter::once(elem).chain(b)))
+}
+
+/// Returns `Cow::Borrowed` `a` if `a` contains the same elements as yielded by `b`'s iterator.
+///
+/// Collects into a new `A::Owned` and returns `Cow::Owned` if either the number of elements or the
+/// elements themselves differ.
+///
+/// # Examples
+///
+/// ```
+/// use itertools::copy_on_diff;
+/// use std::borrow::Cow;
+///
+/// let a = vec![0, 1, 2];
+/// let b = vec![0.0, 1.0, 2.0];
+/// let b_map = b.into_iter().map(|f| f as i32);
+/// let a_cow = copy_on_diff(&a, b_map);
+///
+/// assert!(match a_cow {
+///     Cow::Borrowed(slice) => slice == &a,
+///     _ => false,
+/// });
+/// ```
+///
+/// ```
+/// use itertools::copy_on_diff;
+/// use std::borrow::Cow;
+///
+/// let a = vec![0, 1, 2, 3];
+/// let b = vec![0.0, 1.0, 2.0];
+/// let b_map = b.into_iter().map(|f| f as i32);
+/// let a_cow = copy_on_diff(&a, b_map);
+///
+/// assert!(match a_cow {
+///     Cow::Owned(vec) => vec == vec![0, 1, 2],
+///     _ => false,
+/// });
+/// ```
+pub fn copy_on_diff<'a, A, B, T: 'a>(a: &'a A, b: B) -> Cow<'a, A>
+    where &'a A: IntoIterator<Item=&'a T>,
+          <&'a A as IntoIterator>::IntoIter: Clone,
+          A: ToOwned,
+          <A as ToOwned>::Owned: iter::FromIterator<T>,
+          B: IntoIterator<Item=T>,
+          T: Clone + PartialEq,
+{
+    let a_iter = a.into_iter();
+    match iter_diff(a_iter.clone(), b.into_iter()) {
+        Some(IterDiff::FirstMismatch(i, mismatch)) =>
+            Cow::Owned(a_iter.take(i).cloned().chain(mismatch).collect()),
+        Some(IterDiff::Longer(remaining)) =>
+            Cow::Owned(a_iter.cloned().chain(remaining).collect()),
+        Some(IterDiff::Shorter(num_new_elems)) =>
+            Cow::Owned(a_iter.cloned().take(num_new_elems).collect()),
+        None => Cow::Borrowed(a),
+    }
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,72 +1,75 @@
 //! "Diff"ing iterators for caching elements to sequential collections without requiring the new
 //! elements' iterator to be `Clone`.
 //!
-//! - [**IterDiff**](./enum.IterDiff.html) (produced by the [**iter_diff**](./fn.iter_diff.html)
-//! function) describes the difference between two non-`Clone` iterators `a` and `b` after breaking
-//! ASAP from a comparison with enough data to update `a`'s collection.
-//! - [**copy_on_diff**](./fn.copy_on_diff.html) is an application of [**iter_diff**] that compares
-//! two iterators `a` and `b`, borrowing the source of `a` if they are the same or creating a new
-//! owned collection with `b`'s elements if they are different.
+//! - [**Diff**](./enum.Diff.html) (produced by the [**diff**](./fn.diff.html) function) describes
+//! the difference between two non-`Clone` iterators `a` and `b` after breaking ASAP from a
+//! comparison with enough data to update `a`'s collection.
+//! - [**copy_on_diff**](./fn.copy_on_diff.html) is an application of [**diff**] that compares two
+//! iterators `a` and `b`, borrowing the source of `a` if they are the same or creating a new owned
+//! collection with `b`'s elements if they are different.
 
 use std::borrow::{Cow, ToOwned};
 use std::iter;
 
-/// A type returned by the [`iter_diff`](./fn.iter_diff.html) function.
+/// A type returned by the [`diff`](./fn.diff.html) function.
 ///
-/// `IterDiff` represents the way in which the elements (of type `E`) yielded by the iterator `I`
+/// `Diff` represents the way in which the elements (of type `E`) yielded by the iterator `I`
 /// differ to some other iterator yielding borrowed elements of the same type.
 ///
 /// `I` is some `Iterator` yielding elements of type `E`.
-pub enum IterDiff<E, I> {
+pub enum Diff<I>
+    where I: Iterator,
+{
     /// The index of the first non-matching element along with the iterator's remaining elements
     /// starting with the first mis-matched element.
-    FirstMismatch(usize, iter::Chain<iter::Once<E>, I>),
+    FirstMismatch(usize, iter::Chain<iter::Once<I::Item>, I>),
     /// The remaining elements of the iterator.
-    Longer(iter::Chain<iter::Once<E>, I>),
+    Longer(iter::Chain<iter::Once<I::Item>, I>),
     /// The total number of elements that were in the iterator.
     Shorter(usize),
 }
 
-/// Compares every element yielded by both elems and new_elems in lock-step and returns an
-/// `IterDiff` which describes how `b` differs from `a`.
+/// Compares every element yielded by both elems and new_elems in lock-step and returns a `Diff`
+/// which describes how `j` differs from `i`.
 ///
-/// This function is useful for caching some iterator `b` in some sequential collection without
-/// requiring `b` to be `Clone` in order to compare it to the collection before determining if the
+/// This function is useful for caching some iterator `j` in some sequential collection without
+/// requiring `j` to be `Clone` in order to compare it to the collection before determining if the
 /// collection needs to be updated. The returned function returns as soon as a difference is found,
-/// producing an `IterDiff` that provides the data necessary to update the collection without ever
-/// requiring `B` to be `Clone`. This allows for efficiently caching iterators like `Map` or
+/// producing a `Diff` that provides the data necessary to update the collection without ever
+/// requiring `J` to be `Clone`. This allows for efficiently caching iterators like `Map` or
 /// `Filter` that do not implement `Clone`.
 ///
-/// If the number of elements yielded by `b` is less than the number of elements yielded by `a`,
-/// the number of `b` elements yielded will be returned as `IterDiff::Shorter`.
+/// If the number of elements yielded by `j` is less than the number of elements yielded by `i`,
+/// the number of `j` elements yielded will be returned as `Diff::Shorter`.
 ///
 /// If the two elements of a step differ, the index of those elements along with the remaining
-/// elements of `b` are returned as `IterDiff::FirstMismatch`.
+/// elements of `j` are returned as `Diff::FirstMismatch`.
 ///
-/// If `a` becomes exhausted before `b` becomes exhausted, the remaining `b` elements will be
-/// returned as `IterDiff::Longer`.
+/// If `i` becomes exhausted before `j` becomes exhausted, the remaining `j` elements will be
+/// returned as `Diff::Longer`.
 ///
-/// See [`copy_on_diff`](./fn.copy_on_diff.html) for an application of `iter_diff`.
-pub fn iter_diff<'a, A, B>(a: A, b: B) -> Option<IterDiff<B::Item, B::IntoIter>>
-    where A: IntoIterator<Item=&'a B::Item>,
-          B: IntoIterator,
-          B::Item: PartialEq + 'a,
+/// See [`copy_on_diff`](./fn.copy_on_diff.html) for an application of `diff`.
+pub fn diff<'a, I, J>(i: I, j: J) -> Option<Diff<J::IntoIter>>
+    where I: IntoIterator<Item=&'a J::Item>,
+          J: IntoIterator,
+          J::Item: PartialEq + 'a,
 {
-    let mut b = b.into_iter();
-    for (i, a_elem) in a.into_iter().enumerate() {
-        match b.next() {
-            None => return Some(IterDiff::Shorter(i)),
-            Some(b_elem) => if *a_elem != b_elem {
-                return Some(IterDiff::FirstMismatch(i, iter::once(b_elem).chain(b)));
+    let mut j = j.into_iter();
+    for (idx, i_elem) in i.into_iter().enumerate() {
+        match j.next() {
+            None => return Some(Diff::Shorter(idx)),
+            Some(j_elem) => if *i_elem != j_elem {
+                return Some(Diff::FirstMismatch(idx, iter::once(j_elem).chain(j)));
             },
         }
     }
-    b.next().map(|elem| IterDiff::Longer(iter::once(elem).chain(b)))
+    j.next().map(|elem| Diff::Longer(iter::once(elem).chain(j)))
 }
 
-/// Returns `Cow::Borrowed` `a` if `a` contains the same elements as yielded by `b`'s iterator.
+/// Returns `Cow::Borrowed` `collection` if `collection` contains the same elements as yielded by
+/// `update`'s iterator.
 ///
-/// Collects into a new `A::Owned` and returns `Cow::Owned` if either the number of elements or the
+/// Collects into a new `C::Owned` and returns `Cow::Owned` if either the number of elements or the
 /// elements themselves differ.
 ///
 /// # Examples
@@ -78,9 +81,9 @@ pub fn iter_diff<'a, A, B>(a: A, b: B) -> Option<IterDiff<B::Item, B::IntoIter>>
 /// let a = vec![0, 1, 2];
 /// let b = vec![0.0, 1.0, 2.0];
 /// let b_map = b.into_iter().map(|f| f as i32);
-/// let a_cow = copy_on_diff(&a, b_map);
+/// let cow = copy_on_diff(&a, b_map);
 ///
-/// assert!(match a_cow {
+/// assert!(match cow {
 ///     Cow::Borrowed(slice) => slice == &a,
 ///     _ => false,
 /// });
@@ -93,29 +96,31 @@ pub fn iter_diff<'a, A, B>(a: A, b: B) -> Option<IterDiff<B::Item, B::IntoIter>>
 /// let a = vec![0, 1, 2, 3];
 /// let b = vec![0.0, 1.0, 2.0];
 /// let b_map = b.into_iter().map(|f| f as i32);
-/// let a_cow = copy_on_diff(&a, b_map);
+/// let cow = copy_on_diff(&a, b_map);
 ///
-/// assert!(match a_cow {
+/// assert!(match cow {
 ///     Cow::Owned(vec) => vec == vec![0, 1, 2],
 ///     _ => false,
 /// });
 /// ```
-pub fn copy_on_diff<'a, A, B, T: 'a>(a: &'a A, b: B) -> Cow<'a, A>
-    where &'a A: IntoIterator<Item=&'a T>,
-          <&'a A as IntoIterator>::IntoIter: Clone,
-          A: ToOwned,
-          <A as ToOwned>::Owned: iter::FromIterator<T>,
-          B: IntoIterator<Item=T>,
+pub fn copy_on_diff<'a, C, U, T: 'a>(collection: &'a C, update: U) -> Cow<'a, C>
+    where &'a C: IntoIterator<Item=&'a T>,
+          <&'a C as IntoIterator>::IntoIter: Clone,
+          C: ToOwned,
+          <C as ToOwned>::Owned: iter::FromIterator<T>,
+          U: IntoIterator<Item=T>,
           T: Clone + PartialEq,
 {
-    let a_iter = a.into_iter();
-    match iter_diff(a_iter.clone(), b.into_iter()) {
-        Some(IterDiff::FirstMismatch(i, mismatch)) =>
-            Cow::Owned(a_iter.take(i).cloned().chain(mismatch).collect()),
-        Some(IterDiff::Longer(remaining)) =>
-            Cow::Owned(a_iter.cloned().chain(remaining).collect()),
-        Some(IterDiff::Shorter(num_new_elems)) =>
-            Cow::Owned(a_iter.cloned().take(num_new_elems).collect()),
-        None => Cow::Borrowed(a),
+    let c_iter = collection.into_iter();
+    match diff(c_iter.clone(), update.into_iter()) {
+        Some(diff) => match diff {
+            Diff::FirstMismatch(idx, mismatch) =>
+                Cow::Owned(c_iter.take(idx).cloned().chain(mismatch).collect()),
+            Diff::Longer(remaining) =>
+                Cow::Owned(c_iter.cloned().chain(remaining).collect()),
+            Diff::Shorter(num_update) =>
+                Cow::Owned(c_iter.cloned().take(num_update).collect()),
+        },
+        None => Cow::Borrowed(collection),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use adaptors::{
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
-pub use diff::{diff, diff_by_ref, Diff};
+pub use diff::{diff_with, Diff};
 pub use free::{enumerate, rev};
 pub use format::Format;
 pub use groupbylazy::{ChunksLazy, Chunk, Chunks, GroupByLazy, Group, Groups};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use adaptors::{
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
-pub use diff::{copy_on_diff, diff, diff_by_ref, Diff};
+pub use diff::{diff, diff_by_ref, Diff};
 pub use free::{enumerate, rev};
 pub use format::Format;
 pub use groupbylazy::{ChunksLazy, Chunk, Chunks, GroupByLazy, Group, Groups};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use adaptors::{
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
-pub use diff::{copy_on_diff, iter_diff, IterDiff};
+pub use diff::{copy_on_diff, diff, diff_by_ref, Diff};
 pub use free::{enumerate, rev};
 pub use format::Format;
 pub use groupbylazy::{ChunksLazy, Chunk, Chunks, GroupByLazy, Group, Groups};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub use adaptors::{
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
+pub use diff::{copy_on_diff, iter_diff, IterDiff};
 pub use free::{enumerate, rev};
 pub use format::Format;
 pub use groupbylazy::{ChunksLazy, Chunk, Chunks, GroupByLazy, Group, Groups};
@@ -93,6 +94,7 @@ mod format;
 mod groupbylazy;
 mod intersperse;
 mod islice;
+mod diff;
 mod linspace;
 pub mod misc;
 mod pad_tail;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -856,7 +856,7 @@ fn diff_mismatch() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 5.0, 3.0, 4.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::diff_by_ref(a.iter(), b_map);
+    let diff = it::diff_with(a.iter(), b_map, |a, b| *a != b);
 
     assert!(match diff {
         Some(it::Diff::FirstMismatch(1, _, from_diff)) =>
@@ -870,7 +870,7 @@ fn diff_longer() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::diff_by_ref(a.iter(), b_map);
+    let diff = it::diff_with(a.iter(), b_map, |a, b| *a != b);
 
     assert!(match diff {
         Some(it::Diff::Longer(_, remaining)) =>
@@ -884,7 +884,7 @@ fn diff_shorter() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 2.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::diff_by_ref(a.iter(), b_map);
+    let diff = it::diff_with(a.iter(), b_map, |a, b| *a != b);
 
     assert!(match diff {
         Some(it::Diff::Shorter(len, _)) => len == 2,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -852,42 +852,42 @@ fn combinations_n() {
 }
 
 #[test]
-fn iter_diff_mismatch() {
+fn diff_mismatch() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 5.0, 3.0, 4.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::iter_diff(a.iter(), b_map);
+    let diff = it::diff(a.iter(), b_map);
 
     assert!(match diff {
-        Some(it::IterDiff::FirstMismatch(1, from_diff)) =>
+        Some(it::Diff::FirstMismatch(1, from_diff)) =>
             from_diff.collect::<Vec<_>>() == vec![5, 3, 4],
         _ => false,
     });
 }
 
 #[test]
-fn iter_diff_longer() {
+fn diff_longer() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::iter_diff(a.iter(), b_map);
+    let diff = it::diff(a.iter(), b_map);
 
     assert!(match diff {
-        Some(it::IterDiff::Longer(remaining)) =>
+        Some(it::Diff::Longer(remaining)) =>
             remaining.collect::<Vec<_>>() == vec![5, 6],
         _ => false,
     });
 }
 
 #[test]
-fn iter_diff_shorter() {
+fn diff_shorter() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 2.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::iter_diff(a.iter(), b_map);
+    let diff = it::diff(a.iter(), b_map);
 
     assert!(match diff {
-        Some(it::IterDiff::Shorter(len)) => len == 2,
+        Some(it::Diff::Shorter(len)) => len == 2,
         _ => false,
     });
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -850,3 +850,44 @@ fn combinations_n() {
     it::assert_equal((0..2).combinations_n(1), vec![vec![0], vec![1]]);
     it::assert_equal((0..2).combinations_n(2), vec![vec![0, 1]]);
 }
+
+#[test]
+fn iter_diff_mismatch() {
+    let a = vec![1, 2, 3, 4];
+    let b = vec![1.0, 5.0, 3.0, 4.0];
+    let b_map = b.into_iter().map(|f| f as i32);
+    let diff = it::iter_diff(a.iter(), b_map);
+
+    assert!(match diff {
+        Some(it::IterDiff::FirstMismatch(1, from_diff)) =>
+            from_diff.collect::<Vec<_>>() == vec![5, 3, 4],
+        _ => false,
+    });
+}
+
+#[test]
+fn iter_diff_longer() {
+    let a = vec![1, 2, 3, 4];
+    let b = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let b_map = b.into_iter().map(|f| f as i32);
+    let diff = it::iter_diff(a.iter(), b_map);
+
+    assert!(match diff {
+        Some(it::IterDiff::Longer(remaining)) =>
+            remaining.collect::<Vec<_>>() == vec![5, 6],
+        _ => false,
+    });
+}
+
+#[test]
+fn iter_diff_shorter() {
+    let a = vec![1, 2, 3, 4];
+    let b = vec![1.0, 2.0];
+    let b_map = b.into_iter().map(|f| f as i32);
+    let diff = it::iter_diff(a.iter(), b_map);
+
+    assert!(match diff {
+        Some(it::IterDiff::Shorter(len)) => len == 2,
+        _ => false,
+    });
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -856,10 +856,10 @@ fn diff_mismatch() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 5.0, 3.0, 4.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::diff(a.iter(), b_map);
+    let diff = it::diff_by_ref(a.iter(), b_map);
 
     assert!(match diff {
-        Some(it::Diff::FirstMismatch(1, from_diff)) =>
+        Some(it::Diff::FirstMismatch(1, _, from_diff)) =>
             from_diff.collect::<Vec<_>>() == vec![5, 3, 4],
         _ => false,
     });
@@ -870,10 +870,10 @@ fn diff_longer() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::diff(a.iter(), b_map);
+    let diff = it::diff_by_ref(a.iter(), b_map);
 
     assert!(match diff {
-        Some(it::Diff::Longer(remaining)) =>
+        Some(it::Diff::Longer(_, remaining)) =>
             remaining.collect::<Vec<_>>() == vec![5, 6],
         _ => false,
     });
@@ -884,10 +884,10 @@ fn diff_shorter() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 2.0];
     let b_map = b.into_iter().map(|f| f as i32);
-    let diff = it::diff(a.iter(), b_map);
+    let diff = it::diff_by_ref(a.iter(), b_map);
 
     assert!(match diff {
-        Some(it::Diff::Shorter(len)) => len == 2,
+        Some(it::Diff::Shorter(len, _)) => len == 2,
         _ => false,
     });
 }


### PR DESCRIPTION
I originally wrote this module for a couple of cases in conrod where I wanted to cache a non-`Clone` iterator without having to collect the iterator into a `Vec` for comparison in case the cache needed updating.

I've just come across another similar case in a personal project, so before copying code across I thought I'd approach the itertools team in case you deem it worthy of adding to your luscious collection.

Either way, any feedback appreciated!