### PR TITLE
Add combinations_n

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -1126,14 +1126,16 @@ struct LazyBuffer<I: Iterator> {
     buffer: Vec<I::Item>,
 }
 
-impl<I> LazyBuffer<I> where I: Iterator + Clone {
+impl<I> LazyBuffer<I> where I: Iterator {
     pub fn new(it: I) -> LazyBuffer<I> {
-        let mut it = it.clone();
-        let first = it.next();
-        let done = first.is_none();
+        let mut it = it;
         let mut buffer = Vec::new();
-        if !done {
-            buffer.push(first.unwrap());
+        let done;
+        if let Some(first) = it.next() {
+            buffer.push(first);
+            done = false;
+        } else {
+            done = true;
         }
         LazyBuffer {
             it: it,
@@ -1176,7 +1178,7 @@ impl<I> Index<usize> for LazyBuffer<I> where I: Iterator, I::Item: Sized {
     }
 }
 
-/// An iterator to iterate through all the `n`-length combinations in a `Clone`-able iterator.
+/// An iterator to iterate through all the `n`-length combinations in an iterator.
 ///
 /// See [*.combinations_n()*](trait.Itertools.html#method.combinations_n) for more information.
 pub struct CombinationsN<I: Iterator> {
@@ -1185,7 +1187,7 @@ pub struct CombinationsN<I: Iterator> {
     pool: LazyBuffer<I>,
     first: bool,
 }
-impl<I> CombinationsN<I> where I: Iterator + Clone {
+impl<I> CombinationsN<I> where I: Iterator {
     /// Create a new `CombinationsN` from a clonable iterator.
     pub fn new(iter: I, n: usize) -> CombinationsN<I> {
         let mut indices: Vec<usize> = Vec::with_capacity(n);
@@ -1209,7 +1211,7 @@ impl<I> CombinationsN<I> where I: Iterator + Clone {
     }
 }
 
-impl<I> Iterator for CombinationsN<I> where I: Iterator + Clone, I::Item: Clone {
+impl<I> Iterator for CombinationsN<I> where I: Iterator, I::Item: Clone {
     type Item = Vec<I::Item>;
     fn next(&mut self) -> Option<Self::Item> {
         let mut pool_len = self.pool.len();

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -10,6 +10,7 @@ use std::mem;
 use std::num::One;
 #[cfg(feature = "unstable")]
 use std::ops::Add;
+use std::ops::Index;
 use std::iter::{Fuse, Peekable, FlatMap};
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -1080,7 +1081,7 @@ impl<I> Combinations<I> where I: Iterator + Clone {
     }
 }
 
-impl<I> Iterator for Combinations<I> where I: Iterator + Clone, I::Item: Clone{
+impl<I> Iterator for Combinations<I> where I: Iterator + Clone, I::Item: Clone {
     type Item = (I::Item, I::Item);
     fn next(&mut self) -> Option<Self::Item> {
         // not having a value means we iterate once more through the first iterator
@@ -1116,6 +1117,145 @@ impl<I> Iterator for Combinations<I> where I: Iterator + Clone, I::Item: Clone{
         }
         // won't truncate because x * (x - 1) is guarenteed to be even
         size_hint::add((lo / 2, hi.map(|hi| hi / 2)), extra)
+    }
+}
+
+struct LazyBuffer<I: Iterator> {
+    it: I,
+    done: bool,
+    buffer: Vec<I::Item>,
+}
+
+impl<I> LazyBuffer<I> where I: Iterator + Clone {
+    pub fn new(it: I) -> LazyBuffer<I> {
+        let mut it = it.clone();
+        let first = it.next();
+        let done = first.is_none();
+        let mut buffer = Vec::new();
+        if !done {
+            buffer.push(first.unwrap());
+        }
+        LazyBuffer {
+            it: it,
+            done: done,
+            buffer: buffer,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    pub fn get_next(&mut self) -> bool {
+        if self.done {
+            return false;
+        }
+        let next_item = self.it.next();
+        match next_item {
+            Some(x) => {
+                self.buffer.push(x);
+                true
+            },
+            None => {
+                self.done = true;
+                false
+            },
+        }
+    }
+}
+
+impl<I> Index<usize> for LazyBuffer<I> where I: Iterator, I::Item: Sized {
+    type Output = I::Item;
+
+    fn index<'b>(&'b self, _index: usize) -> &'b I::Item {
+        self.buffer.index(_index)
+    }
+}
+
+/// An iterator to iterate through all the `n`-length combinations in a `Clone`-able iterator.
+///
+/// See [*.combinations_n()*](trait.Itertools.html#method.combinations_n) for more information.
+pub struct CombinationsN<I: Iterator> {
+    n: usize,
+    indices: Vec<usize>,
+    pool: LazyBuffer<I>,
+    first: bool,
+}
+impl<I> CombinationsN<I> where I: Iterator + Clone {
+    /// Create a new `CombinationsN` from a clonable iterator.
+    pub fn new(iter: I, n: usize) -> CombinationsN<I> {
+        let mut indices: Vec<usize> = Vec::with_capacity(n);
+        for i in 0..n {
+            indices.push(i);
+        }
+        let mut pool: LazyBuffer<I> = LazyBuffer::new(iter);
+
+        for _ in 0..n {
+            if !pool.get_next() {
+                break;
+            }
+        }
+
+        CombinationsN {
+            n: n,
+            indices: indices,
+            pool: pool,
+            first: true,
+        }
+    }
+}
+
+impl<I> Iterator for CombinationsN<I> where I: Iterator + Clone, I::Item: Clone {
+    type Item = Vec<I::Item>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut pool_len = self.pool.len();
+        if self.pool.is_done() {
+            if pool_len == 0 || self.n > pool_len {
+                return None;
+            }
+        }
+
+        if self.first {
+            self.first = false;
+        } else {
+            // Scan from the end, looking for an index to increment
+            let mut i: usize = self.n - 1;
+
+            // Check if we need to consume more from the iterator
+            if self.indices[i] == pool_len - 1 && !self.pool.is_done() {
+                if self.pool.get_next() {
+                    pool_len += 1;
+                }
+            }
+
+            while self.indices[i] == i + pool_len - self.n {
+                if i > 0 {
+                    i -= 1;
+                } else {
+                    // Reached the last combination
+                    return None;
+                }
+            }
+
+            // Increment index, and reset the ones to its right
+            self.indices[i] += 1;
+            let mut j: usize = i + 1;
+            while j < self.n {
+                self.indices[j] = self.indices[j-1] + 1;
+                j += 1;
+            }
+        }
+
+        // Create result vector based on the indices
+        let mut result: Self::Item = Vec::with_capacity(self.n);
+        for i in self.indices.iter() {
+            result.push(self.pool[*i].clone());
+        }
+        Some(result)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub use adaptors::{
     Coalesce,
     MendSlices,
     Combinations,
+    CombinationsN,
     Unique,
     UniqueBy,
     Flatten,
@@ -792,6 +793,28 @@ pub trait Itertools : Iterator {
         Self: Sized + Clone, Self::Item: Clone
     {
         Combinations::new(self)
+    }
+
+    /// Return an iterator adaptor that iterates over the `n`-length combinations of
+    /// the elements from an iterator.
+    ///
+    /// Iterator element type is `Vec<Self::Item, Self::Item>`.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let it = (1..5).combinations_n(3);
+    /// itertools::assert_equal(it, vec![
+    ///     vec![1, 2, 3],
+    ///     vec![1, 2, 4],
+    ///     vec![1, 3, 4],
+    ///     vec![2, 3, 4],
+    ///     ]);
+    /// ```
+    fn combinations_n(self, n: usize) -> CombinationsN<Self> where
+        Self: Sized + Clone, Self::Item: Clone
+    {
+        CombinationsN::new(self, n)
     }
 
     /// Return an iterator adaptor that pads the sequence to a minimum length of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -798,7 +798,8 @@ pub trait Itertools : Iterator {
     /// Return an iterator adaptor that iterates over the `n`-length combinations of
     /// the elements from an iterator.
     ///
-    /// Iterator element type is `Vec<Self::Item, Self::Item>`.
+    /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new Vec per iteration,
+    /// and clones the iterator elements.
     ///
     /// ```
     /// use itertools::Itertools;
@@ -812,7 +813,7 @@ pub trait Itertools : Iterator {
     ///     ]);
     /// ```
     fn combinations_n(self, n: usize) -> CombinationsN<Self> where
-        Self: Sized + Clone, Self::Item: Clone
+        Self: Sized, Self::Item: Clone
     {
         CombinationsN::new(self, n)
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -821,3 +821,23 @@ fn flatten_clone() {
     it::assert_equal(flattened1, &[1,2,3,4,5,6]);
     it::assert_equal(flattened2, &[1,2,3,4,5,6]);
 }
+
+#[test]
+fn combinations_n() {
+    assert!((1..3).combinations_n(5).next().is_none());
+
+    let it = (1..3).combinations_n(2);
+    it::assert_equal(it, vec![
+        vec![1, 2],
+        ]);
+
+    let it = (1..5).combinations_n(2);
+    it::assert_equal(it, vec![
+        vec![1, 2],
+        vec![1, 3],
+        vec![1, 4],
+        vec![2, 3],
+        vec![2, 4],
+        vec![3, 4],
+        ]);
+}


### PR DESCRIPTION
itertools already provides ```combinations``` which returns all choices of 2 items. It Seemed odd that it doesn't provide a more general form.

```combinations_n``` returns all possible choices of n items from a given iterator.

Perhaps this implementation isn't a good fit for the library. Up to you to decide.

A few issues:

1. I've implemented lazy buffering. combinations_n only consumes data from the iterator when it has to. However, I don't know if the implementation is good enough, or if I placed it in the right file.
2. I couldn't manage to set the Clone trait correctly on the new structs (due to being new to Rust), so I removed it.
