### PR TITLE
Add k-way merge adaptor.

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -637,3 +637,69 @@ fn merge_by_lt(b: &mut test::Bencher) {
         data1.iter().merge_by(&data2, |a, b| a <= b).count()
     })
 }
+
+#[bench]
+fn kmerge_default(b: &mut test::Bencher) {
+    let mut data1 = vec![0; 1024];
+    let mut data2 = vec![0; 800];
+    let mut x = 0;
+    for (_, elt) in data1.iter_mut().enumerate() {
+        *elt = x;
+        x += 1;
+    }
+
+    let mut y = 0;
+    for (i, elt) in data2.iter_mut().enumerate() {
+        *elt += y;
+        if i % 3 == 0 {
+            y += 3;
+        } else {
+            y += 0;
+        }
+    }
+    let data1 = test::black_box(data1);
+    let data2 = test::black_box(data2);
+    let its = &[data1.iter(), data2.iter()];
+    b.iter(|| {
+        its.iter().cloned().kmerge().count()
+    })
+}
+
+#[bench]
+fn kmerge_threeway(b: &mut test::Bencher) {
+    let mut data1 = vec![0; 1024];
+    let mut data2 = vec![0; 800];
+    let mut data3 = vec![0; 1024];
+    let mut x = 0;
+    for (_, elt) in data1.iter_mut().enumerate() {
+        *elt = x;
+        x += 1;
+    }
+
+    let mut y = 0;
+    for (i, elt) in data2.iter_mut().enumerate() {
+        *elt += y;
+        if i % 3 == 0 {
+            y += 3;
+        } else {
+            y += 0;
+        }
+    }
+
+    let mut z = 0;
+    for (i, elt) in data3.iter_mut().enumerate() {
+        *elt += z;
+        if i % 10 == 0 {
+            z += 10;
+        } else {
+            z += 0;
+        }
+    }
+    let data1 = test::black_box(data1);
+    let data2 = test::black_box(data2);
+    let data3 = test::black_box(data3);
+    let its = &[data1.iter(), data2.iter(), data3.iter()];
+    b.iter(|| {
+        its.iter().cloned().kmerge().count()
+    })
+}

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -691,6 +691,12 @@ impl<I, J, F> Iterator for MergeBy<I, J, F> where
 }
 
 /// A non-empty sequence
+///
+/// `PartialEq`, `Eq`, `PartialOrd` and `Ord` are implemented by comparing sequences based on
+/// first items (which are guaranteed to exist).
+///
+/// The meanings of `PartialOrd` and `Ord` are reversed so as to turn the `BinaryHeap` used in
+/// `KMerge` into a min-heap.
 pub struct NonEmpty<I> where
     I: Iterator
 {

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -697,7 +697,7 @@ impl<I, J, F> Iterator for MergeBy<I, J, F> where
 ///
 /// The meanings of `PartialOrd` and `Ord` are reversed so as to turn the `BinaryHeap` used in
 /// `KMerge` into a min-heap.
-pub struct NonEmpty<I> where
+struct NonEmpty<I> where
     I: Iterator
 {
     head: I::Item,

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -747,7 +747,7 @@ impl<I> PartialOrd for NonEmpty<I> where
     I::Item: PartialOrd
 {
     fn partial_cmp(&self, other: &NonEmpty<I>) -> Option<Ordering> {
-        self.head.partial_cmp(&other.head).map(Ordering::reverse)
+        other.head.partial_cmp(&self.head)
     }
 }
 
@@ -756,7 +756,7 @@ impl<I> Ord for NonEmpty<I> where
     I::Item: Ord
 {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.head.cmp(&other.head).reverse()
+        other.head.cmp(&self.head)
     }
 }
 

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -755,6 +755,22 @@ impl<I> PartialOrd for NonEmpty<I> where
     fn partial_cmp(&self, other: &NonEmpty<I>) -> Option<Ordering> {
         other.head.partial_cmp(&self.head)
     }
+
+    fn lt(&self, other: &NonEmpty<I>) -> bool {
+        other.head.lt(&self.head)
+    }
+
+    fn le(&self, other: &NonEmpty<I>) -> bool {
+        other.head.le(&self.head)
+    }
+
+    fn gt(&self, other: &NonEmpty<I>) -> bool {
+        other.head.gt(&self.head)
+    }
+
+    fn ge(&self, other: &NonEmpty<I>) -> bool {
+        other.head.ge(&self.head)
+    }
 }
 
 impl<I> Ord for NonEmpty<I> where

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -12,8 +12,9 @@ use std::num::One;
 use std::ops::Add;
 use std::ops::Index;
 use std::iter::{Fuse, Peekable, FlatMap};
-use std::collections::HashSet;
+use std::collections::{BinaryHeap, HashSet};
 use std::hash::Hash;
+use std::cmp::Ordering;
 use Itertools;
 use size_hint;
 use misc::MendSlice;
@@ -686,6 +687,133 @@ impl<I, J, F> Iterator for MergeBy<I, J, F> where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.merge.size_hint()
+    }
+}
+
+/// A non-empty sequence
+pub struct NonEmpty<I> where
+    I: Iterator
+{
+    head: I::Item,
+    tail: I,
+}
+
+impl<I> NonEmpty<I> where
+    I: Iterator,
+{
+    /// Constructs a `NonEmpty` from an `Iterator`. Returns `None` if the `Iterator` is empty.
+    fn new(mut it: I) -> Option<NonEmpty<I>> {
+        let head = it.next();
+        head.map(|h| NonEmpty { head: h, tail: it })
+    }
+
+    /// Returns the next item in the sequence. If more items remain, the remainder of the sequence
+    /// is returned as well, otherwise `None`.
+    fn next(self) -> (I::Item, Option<Self>) {
+        (self.head, NonEmpty::new(self.tail))
+    }
+
+    /// Hints at the size of the sequence, same as the `Iterator` method.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        size_hint::add_scalar(self.tail.size_hint(), 1)
+    }
+}
+
+impl<I> Clone for NonEmpty<I> where
+    I: Iterator + Clone,
+    I::Item: Clone
+{
+    fn clone(&self) -> Self {
+        clone_fields!(NonEmpty, self, head, tail)
+    }
+}
+
+impl<I> PartialEq for NonEmpty<I> where
+    I: Iterator,
+    I::Item: PartialEq
+{
+    fn eq(&self, other: &NonEmpty<I>) -> bool {
+        self.head.eq(&other.head)
+    }
+}
+
+impl<I> Eq for NonEmpty<I> where
+    I: Iterator,
+    I::Item: Eq
+{ }
+
+impl<I> PartialOrd for NonEmpty<I> where
+    I: Iterator,
+    I::Item: PartialOrd
+{
+    fn partial_cmp(&self, other: &NonEmpty<I>) -> Option<Ordering> {
+        self.head.partial_cmp(&other.head).map(Ordering::reverse)
+    }
+}
+
+impl<I> Ord for NonEmpty<I> where
+    I: Iterator,
+    I::Item: Ord
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.head.cmp(&other.head).reverse()
+    }
+}
+
+/// An iterator adaptor that merges an abitrary number of base iterators in ascending order.
+/// If all base iterators are sorted (ascending), the result is sorted.
+///
+/// Iterator element type is `I::Item`.
+///
+/// See [*.kmerge()*](trait.Itertools.html#method.kmerge) for more information.
+pub struct KMerge<I> where
+    I: Iterator
+{
+    heap: BinaryHeap<NonEmpty<I>>,
+}
+
+/// Create a `KMerge` iterator.
+pub fn kmerge_new<I>(it: I) -> KMerge<<I::Item as IntoIterator>::IntoIter>
+    where I: Iterator,
+          I::Item: IntoIterator,
+          <<I as Iterator>::Item as IntoIterator>::Item: Ord
+{
+    KMerge {
+        heap: it.filter_map(|it| NonEmpty::new(it.into_iter())).collect()
+    }
+}
+
+impl<I> Clone for KMerge<I> where
+    I: Iterator,
+    BinaryHeap<NonEmpty<I>>: Clone
+{
+    fn clone(&self) -> KMerge<I> {
+        clone_fields!(KMerge, self, heap)
+    }
+}
+
+impl<I> Iterator for KMerge<I> where
+    I: Iterator,
+    I::Item: Ord
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.heap.pop().map(|p| {
+            let (h, t) = p.next();
+            t.map(|t| self.heap.push(t));
+            h
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if !self.heap.is_empty() {
+            let mut it = self.heap.iter();
+            let sh0 = it.next().unwrap().size_hint();
+            it.fold(sh0, |acc, it| size_hint::add(acc, it.size_hint()))
+        } else {
+            (0, Some(0))
+        }
     }
 }
 

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -806,8 +806,8 @@ pub fn kmerge_new<I>(it: I) -> KMerge<<I::Item as IntoIterator>::IntoIter>
 }
 
 impl<I> Clone for KMerge<I> where
-    I: Iterator,
-    BinaryHeap<NonEmpty<I>>: Clone
+    I: Iterator + Clone,
+    I::Item: Clone
 {
     fn clone(&self) -> KMerge<I> {
         clone_fields!(KMerge, self, heap)

--- a/src/free.rs
+++ b/src/free.rs
@@ -8,6 +8,7 @@ use std::iter::{self, Zip};
 use {
     Itertools,
     Merge,
+    KMerge,
     Interleave,
 };
 
@@ -198,6 +199,25 @@ pub fn merge<I, J>(i: I, j: J) -> Merge<I::IntoIter, J::IntoIter>
           I::Item: PartialOrd,
 {
     i.into_iter().merge(j)
+}
+
+/// Create an iterator that merges elements of the contained iterators.
+///
+/// Equivalent to `i.into_iter().kmerge()`.
+///
+/// ```
+/// use itertools::free::kmerge;
+///
+/// for elt in kmerge(vec![vec![0, 2, 4], vec![1, 3, 5], vec![6, 7]]) {
+///     /* loop body */
+/// }
+/// ```
+pub fn kmerge<I>(i: I) -> KMerge<<<I as IntoIterator>::Item as IntoIterator>::IntoIter>
+    where I: IntoIterator,
+          I::Item: IntoIterator,
+          <<I as IntoIterator>::Item as IntoIterator>::Item: Ord,
+{
+    i.into_iter().kmerge()
 }
 
 /// Combine all iterator elements into one String, seperated by `sep`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub use adaptors::{
     Step,
     Merge,
     MergeBy,
+    KMerge,
     MultiPeek,
     TakeWhileRef,
     WhileSome,
@@ -530,6 +531,28 @@ pub trait Itertools : Iterator {
         J: IntoIterator<Item=Self::Item>,
     {
         adaptors::merge_new(self, other.into_iter())
+    }
+
+    /// Return an iterator adaptor that merges the base iterators in ascending order.
+    /// If all base iterators are sorted (ascending), the result is sorted.
+    ///
+    /// Iterator element type is `Self::Item`.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let a = (0..6).step(3);
+    /// let b = (1..6).step(3);
+    /// let c = (2..6).step(3);
+    /// let it = vec![a, b, c].into_iter().kmerge();
+    /// itertools::assert_equal(it, vec![0, 1, 2, 3, 4, 5]);
+    /// ```
+    fn kmerge(self) -> KMerge<<<Self as Iterator>::Item as IntoIterator>::IntoIter> where
+        Self: Sized,
+        Self::Item: IntoIterator,
+        <<Self as Iterator>::Item as IntoIterator>::Item: Ord,
+    {
+        adaptors::kmerge_new(self)
     }
 
     /// Return an iterator adaptor that merges the two base iterators in order.

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -234,6 +234,27 @@ fn size_merge(a: Iter<u16>, b: Iter<u16>) -> bool {
 }
 
 #[quickcheck]
+fn equal_kmerge(a: Vec<i16>, b: Vec<i16>, c: Vec<i16>) -> bool {
+    use itertools::free::kmerge;
+    let mut sa = a.clone();
+    let mut sb = b.clone();
+    let mut sc = c.clone();
+    sa.sort();
+    sb.sort();
+    sc.sort();
+    let mut merged = sa.clone();
+    merged.extend(sb.iter().cloned());
+    merged.extend(sc.iter().cloned());
+    merged.sort();
+    itertools::equal(merged.into_iter(), kmerge(vec![sa, sb, sc]))
+}
+#[quickcheck]
+fn size_kmerge(a: Vec<i16>, b: Vec<i16>, c: Vec<i16>) -> bool {
+    use itertools::free::kmerge;
+    correct_size_hint(kmerge(vec![a, b, c]))
+}
+
+#[quickcheck]
 fn size_zip(a: Iter<i16>, b: Iter<i16>, c: Iter<i16>) -> bool {
     let filt = a.clone().dedup();
     correct_size_hint(Zip::new((filt, b.clone(), c.clone()))) &&

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -403,6 +403,31 @@ fn merge_by_btree() {
 }
 
 #[test]
+fn kmerge() {
+    let its = (0..4).map(|s| (s..10).step(4));
+
+    it::assert_equal(its.kmerge(), (0..10));
+}
+
+#[test]
+fn kmerge_empty() {
+    let its = (0..4).map(|_| (0..0));
+    assert_eq!(its.kmerge().next(), None);
+}
+
+#[test]
+fn kmerge_size_hint() {
+    let its = (0..5).map(|_| (0..10));
+    assert_eq!(its.kmerge().size_hint(), (50, Some(50)));
+}
+
+#[test]
+fn kmerge_empty_size_hint() {
+    let its = (0..5).map(|_| (0..0));
+    assert_eq!(its.kmerge().size_hint(), (0, Some(0)));
+}
+
+#[test]
 fn join() {
     let many = [1, 2, 3];
     let one  = [1];


### PR DESCRIPTION
Merges an arbitrary number of iterators in ascending order.

Uses `std`'s `BinaryHeap` to decide which iterator to take from next. This seems quite heavyweight. Two-way merge benchmarks take roughly ten times longer than the dedicated two-way merge adaptor. Profiling identifies `BinaryHeap`s `sift_up` as the hot-spot.

Not completely sure about the interface, the double use of IntoIterator in the free-standing function in particular.