### PR TITLE
Run rustfmt

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -43,19 +43,23 @@ pub struct Interleave<I, J> {
     flag: bool,
 }
 
-impl<I, J> Interleave<I, J> where
-    I: Iterator,
-    J: Iterator,
+impl<I, J> Interleave<I, J>
+    where I: Iterator,
+          J: Iterator
 {
     /// Creat a new `Interleave` iterator.
     pub fn new(a: I, b: J) -> Interleave<I, J> {
-        Interleave{a: a.fuse(), b: b.fuse(), flag: false}
+        Interleave {
+            a: a.fuse(),
+            b: b.fuse(),
+            flag: false,
+        }
     }
 }
 
-impl<I, J> Iterator for Interleave<I, J> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
+impl<I, J> Iterator for Interleave<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
 {
     type Item = I::Item;
     #[inline]
@@ -83,18 +87,18 @@ impl<I, J> Iterator for Interleave<I, J> where
 /// See [*.interleave_shortest()*](trait.Itertools.html#method.interleave_shortest)
 /// for more information.
 #[derive(Clone)]
-pub struct InterleaveShortest<I, J> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
+pub struct InterleaveShortest<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
 {
     it0: I,
     it1: J,
     phase: bool, // false ==> it0, true ==> it1
 }
 
-impl<I, J> InterleaveShortest<I, J> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
+impl<I, J> InterleaveShortest<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
 {
     /// Create a new `InterleaveShortest` iterator.
     pub fn new(a: I, b: J) -> InterleaveShortest<I, J> {
@@ -106,9 +110,9 @@ impl<I, J> InterleaveShortest<I, J> where
     }
 }
 
-impl<I, J> Iterator for InterleaveShortest<I, J> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
+impl<I, J> Iterator for InterleaveShortest<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
 {
     type Item = I::Item;
 
@@ -160,34 +164,37 @@ impl<I, J> Iterator for InterleaveShortest<I, J> where
 /// item to the front of the iterator.
 ///
 /// Iterator element type is `I::Item`.
-pub struct PutBack<I> where
-    I: Iterator,
+pub struct PutBack<I>
+    where I: Iterator
 {
     top: Option<I::Item>,
     iter: I,
 }
 
-impl<I> PutBack<I> where
-    I: Iterator,
+impl<I> PutBack<I>
+    where I: Iterator
 {
     /// Iterator element type is `A`
     #[inline]
-    pub fn new(it: I) -> Self
-    {
-        PutBack{top: None, iter: it}
+    pub fn new(it: I) -> Self {
+        PutBack {
+            top: None,
+            iter: it,
+        }
     }
 
     /// Create a `PutBack` along with the `value` to put back.
     #[inline]
-    pub fn with_value(value: I::Item, it: I) -> Self
-    {
-        PutBack{top: Some(value), iter: it}
+    pub fn with_value(value: I::Item, it: I) -> Self {
+        PutBack {
+            top: Some(value),
+            iter: it,
+        }
     }
 
     /// Split the `PutBack` into its parts.
     #[inline]
-    pub fn into_parts(self) -> (Option<I::Item>, I)
-    {
+    pub fn into_parts(self) -> (Option<I::Item>, I) {
         let PutBack{top, iter} = self;
         (top, iter)
     }
@@ -196,14 +203,13 @@ impl<I> PutBack<I> where
     ///
     /// If a value is already in the put back slot, it is overwritten.
     #[inline]
-    pub fn put_back(&mut self, x: I::Item)
-    {
+    pub fn put_back(&mut self, x: I::Item) {
         self.top = Some(x)
     }
 }
 
-impl<I> Iterator for PutBack<I> where
-    I: Iterator,
+impl<I> Iterator for PutBack<I>
+    where I: Iterator
 {
     type Item = I::Item;
     #[inline]
@@ -224,19 +230,19 @@ impl<I> Iterator for PutBack<I> where
 /// items in front of the iterator.
 ///
 /// Iterator element type is `I::Item`.
-pub struct PutBackN<I: Iterator>
-{
+pub struct PutBackN<I: Iterator> {
     top: Vec<I::Item>,
-    iter: I
+    iter: I,
 }
 
-impl<I: Iterator> PutBackN<I>
-{
+impl<I: Iterator> PutBackN<I> {
     /// Iterator element type is `A`
     #[inline]
-    pub fn new(it: I) -> Self
-    {
-        PutBackN{top: vec![], iter: it}
+    pub fn new(it: I) -> Self {
+        PutBackN {
+            top: vec![],
+            iter: it,
+        }
     }
 
     /// Puts x in front of the iterator.
@@ -253,14 +259,12 @@ impl<I: Iterator> PutBackN<I>
     /// assert!(itertools::equal(it, 0..5));
     /// ```
     #[inline]
-    pub fn put_back(&mut self, x: I::Item)
-    {
+    pub fn put_back(&mut self, x: I::Item) {
         self.top.push(x);
     }
 }
 
-impl<I: Iterator> Iterator for PutBackN<I>
-{
+impl<I: Iterator> Iterator for PutBackN<I> {
     type Item = I::Item;
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
@@ -277,12 +281,11 @@ impl<I: Iterator> Iterator for PutBackN<I>
     }
 }
 
-impl<I: Iterator> Clone for PutBackN<I> where
-    I: Clone,
-    I::Item: Clone
+impl<I: Iterator> Clone for PutBackN<I>
+    where I: Clone,
+          I::Item: Clone
 {
-    fn clone(&self) -> Self
-    {
+    fn clone(&self) -> Self {
         clone_fields!(PutBackN, self, top, iter)
     }
 }
@@ -294,8 +297,8 @@ impl<I: Iterator> Clone for PutBackN<I> where
 /// Iterator element type is `(I::Item, J::Item)`.
 ///
 /// See [*.cartesian_product()*](trait.Itertools.html#method.cartesian_product) for more information.
-pub struct Product<I, J> where
-    I: Iterator,
+pub struct Product<I, J>
+    where I: Iterator
 {
     a: I,
     a_cur: Option<I::Item>,
@@ -303,30 +306,33 @@ pub struct Product<I, J> where
     b_orig: J,
 }
 
-impl<I, J> Product<I, J> where
-    I: Iterator,
-    J: Clone + Iterator,
-    I::Item: Clone,
+impl<I, J> Product<I, J>
+    where I: Iterator,
+          J: Clone + Iterator,
+          I::Item: Clone
 {
     /// Create a new cartesian product iterator
     ///
     /// Iterator element type is `(I::Item, J::Item)`.
-    pub fn new(i: I, j: J) -> Self
-    {
+    pub fn new(i: I, j: J) -> Self {
         let mut i = i;
-        Product{a_cur: i.next(), a: i, b: j.clone(), b_orig: j}
+        Product {
+            a_cur: i.next(),
+            a: i,
+            b: j.clone(),
+            b_orig: j,
+        }
     }
 }
 
 
-impl<I, J> Iterator for Product<I, J> where
-    I: Iterator,
-    J: Clone + Iterator,
-    I::Item: Clone,
+impl<I, J> Iterator for Product<I, J>
+    where I: Iterator,
+          J: Clone + Iterator,
+          I::Item: Clone
 {
     type Item = (I::Item, J::Item);
-    fn next(&mut self) -> Option<(I::Item, J::Item)>
-    {
+    fn next(&mut self) -> Option<(I::Item, J::Item)> {
         let elt_b = match self.b.next() {
             None => {
                 self.b = self.b_orig.clone();
@@ -348,8 +354,7 @@ impl<I, J> Iterator for Product<I, J> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let has_cur = self.a_cur.is_some() as usize;
         // Not ExactSizeIterator because size may be larger than usize
         let (b, _) = self.b.size_hint();
@@ -375,26 +380,23 @@ pub struct Batching<I, F> {
 
 impl<F, I> Batching<I, F> {
     /// Create a new Batching iterator.
-    pub fn new(iter: I, f: F) -> Batching<I, F>
-    {
-        Batching{f: f, iter: iter}
+    pub fn new(iter: I, f: F) -> Batching<I, F> {
+        Batching { f: f, iter: iter }
     }
 }
 
-impl<B, F, I> Iterator for Batching<I, F> where
-    I: Iterator,
-    F: FnMut(&mut I) -> Option<B>,
+impl<B, F, I> Iterator for Batching<I, F>
+    where I: Iterator,
+          F: FnMut(&mut I) -> Option<B>
 {
     type Item = B;
     #[inline]
-    fn next(&mut self) -> Option<B>
-    {
+    fn next(&mut self) -> Option<B> {
         (self.f)(&mut self.iter)
     }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         // No information about closue behavior
         (0, None)
     }
@@ -405,8 +407,8 @@ impl<B, F, I> Iterator for Batching<I, F> where
 /// that map to the same key (“runs”), are returned as the iterator elements.
 ///
 /// See [*.group_by()*](trait.Itertools.html#method.group_by) for more information.
-pub struct GroupBy<K, I, F> where
-    I: Iterator,
+pub struct GroupBy<K, I, F>
+    where I: Iterator
 {
     key: F,
     iter: I,
@@ -414,33 +416,38 @@ pub struct GroupBy<K, I, F> where
     elts: Vec<I::Item>,
 }
 
-impl<K, F, I> GroupBy<K, I, F> where
-    I: Iterator,
+impl<K, F, I> GroupBy<K, I, F>
+    where I: Iterator
 {
     /// Create a new `GroupBy` iterator.
-    pub fn new(iter: I, key: F) -> Self
-    {
-        GroupBy{key: key, iter: iter, current_key: None, elts: Vec::new()}
+    pub fn new(iter: I, key: F) -> Self {
+        GroupBy {
+            key: key,
+            iter: iter,
+            current_key: None,
+            elts: Vec::new(),
+        }
     }
 }
 
-impl<K, I, F> Iterator for GroupBy<K, I, F> where
-    K: PartialEq,
-    I: Iterator,
-    F: FnMut(&I::Item) -> K,
+impl<K, I, F> Iterator for GroupBy<K, I, F>
+    where K: PartialEq,
+          I: Iterator,
+          F: FnMut(&I::Item) -> K
 {
     type Item = (K, Vec<I::Item>);
-    fn next(&mut self) -> Option<(K, Vec<I::Item>)>
-    {
+    fn next(&mut self) -> Option<(K, Vec<I::Item>)> {
         for elt in self.iter.by_ref() {
             let key = (self.key)(&elt);
             match self.current_key.take() {
                 None => {}
-                Some(old_key) => if old_key != key {
-                    self.current_key = Some(key);
-                    let v = mem::replace(&mut self.elts, vec![elt]);
-                    return Some((old_key, v))
-                },
+                Some(old_key) => {
+                    if old_key != key {
+                        self.current_key = Some(key);
+                        let v = mem::replace(&mut self.elts, vec![elt]);
+                        return Some((old_key, v));
+                    }
+                }
             }
             self.current_key = Some(key);
             self.elts.push(elt);
@@ -454,11 +461,9 @@ impl<K, I, F> Iterator for GroupBy<K, I, F> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let stored_count = self.current_key.is_some() as usize;
-        let mut sh = size_hint::add_scalar(self.iter.size_hint(),
-                                           stored_count);
+        let mut sh = size_hint::add_scalar(self.iter.size_hint(), stored_count);
         if sh.0 > 0 {
             sh.0 = 1;
         }
@@ -479,31 +484,33 @@ pub struct Step<I> {
     skip: usize,
 }
 
-impl<I> Step<I> where I: Iterator
+impl<I> Step<I>
+    where I: Iterator
 {
     /// Create a `Step` iterator.
     ///
     /// **Panics** if the step is 0.
-    pub fn new(iter: I, step: usize) -> Self
-    {
+    pub fn new(iter: I, step: usize) -> Self {
         assert!(step != 0);
-        Step{iter: iter.fuse(), skip: step - 1}
+        Step {
+            iter: iter.fuse(),
+            skip: step - 1,
+        }
     }
 }
 
-impl<I> Iterator for Step<I> where I: Iterator
+impl<I> Iterator for Step<I>
+    where I: Iterator
 {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item>
-    {
+    fn next(&mut self) -> Option<I::Item> {
         let elt = self.iter.next();
         self.iter.dropn(self.skip);
         elt
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let (low, high) = self.iter.size_hint();
         let div = |x: usize| {
             if x == 0 {
@@ -517,14 +524,14 @@ impl<I> Iterator for Step<I> where I: Iterator
 }
 
 // known size
-impl<I> ExactSizeIterator for Step<I> where
-    I: ExactSizeIterator,
-{ }
+impl<I> ExactSizeIterator for Step<I>
+    where I: ExactSizeIterator
+{}
 
 
 struct MergeCore<I, J>
     where I: Iterator,
-          J: Iterator<Item=I::Item>,
+          J: Iterator<Item = I::Item>
 {
     a: Peekable<I>,
     b: Peekable<J>,
@@ -532,11 +539,11 @@ struct MergeCore<I, J>
 }
 
 
-impl<I, J> Clone for MergeCore<I, J> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
-    Peekable<I>: Clone,
-    Peekable<J>: Clone,
+impl<I, J> Clone for MergeCore<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>,
+          Peekable<I>: Clone,
+          Peekable<J>: Clone
 {
     fn clone(&self) -> Self {
         clone_fields!(MergeCore, self, a, b, fused)
@@ -545,7 +552,7 @@ impl<I, J> Clone for MergeCore<I, J> where
 
 impl<I, J> MergeCore<I, J>
     where I: Iterator,
-          J: Iterator<Item=I::Item>,
+          J: Iterator<Item = I::Item>
 {
     fn next_with<F>(&mut self, mut less_than: F) -> Option<I::Item>
         where F: FnMut(&I::Item, &I::Item) -> bool
@@ -585,18 +592,18 @@ impl<I, J> MergeCore<I, J>
 /// Iterator element type is `I::Item`.
 ///
 /// See [*.merge()*](trait.Itertools.html#method.merge_by) for more information.
-pub struct Merge<I, J> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
+pub struct Merge<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
 {
     merge: MergeCore<I, J>,
 }
 
-impl<I, J> Clone for Merge<I, J> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
-    Peekable<I>: Clone,
-    Peekable<J>: Clone,
+impl<I, J> Clone for Merge<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>,
+          Peekable<I>: Clone,
+          Peekable<J>: Clone
 {
     fn clone(&self) -> Self {
         clone_fields!(Merge, self, merge)
@@ -606,21 +613,21 @@ impl<I, J> Clone for Merge<I, J> where
 /// Create a `Merge` iterator.
 pub fn merge_new<I, J>(a: I, b: J) -> Merge<I, J>
     where I: Iterator,
-          J: Iterator<Item=I::Item>,
+          J: Iterator<Item = I::Item>
 {
     Merge {
         merge: MergeCore {
             a: a.peekable(),
             b: b.peekable(),
             fused: None,
-        }
+        },
     }
 }
 
 impl<I, J> Iterator for Merge<I, J>
     where I: Iterator,
-          J: Iterator<Item=I::Item>,
-          I::Item: PartialOrd,
+          J: Iterator<Item = I::Item>,
+          I::Item: PartialOrd
 {
     type Item = I::Item;
 
@@ -639,9 +646,9 @@ impl<I, J> Iterator for Merge<I, J>
 /// Iterator element type is `I::Item`.
 ///
 /// See [*.merge_by()*](trait.Itertools.html#method.merge_by) for more information.
-pub struct MergeBy<I, J, F> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
+pub struct MergeBy<I, J, F>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
 {
     merge: MergeCore<I, J>,
     cmp: F,
@@ -650,7 +657,7 @@ pub struct MergeBy<I, J, F> where
 /// Create a `MergeBy` iterator.
 pub fn merge_by_new<I, J, F>(a: I, b: J, cmp: F) -> MergeBy<I, J, F>
     where I: Iterator,
-          J: Iterator<Item=I::Item>,
+          J: Iterator<Item = I::Item>
 {
     MergeBy {
         merge: MergeCore {
@@ -662,22 +669,22 @@ pub fn merge_by_new<I, J, F>(a: I, b: J, cmp: F) -> MergeBy<I, J, F>
     }
 }
 
-impl<I, J, F> Clone for MergeBy<I, J, F> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
-    Peekable<I>: Clone,
-    Peekable<J>: Clone,
-    F: Clone,
+impl<I, J, F> Clone for MergeBy<I, J, F>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>,
+          Peekable<I>: Clone,
+          Peekable<J>: Clone,
+          F: Clone
 {
     fn clone(&self) -> Self {
         clone_fields!(MergeBy, self, merge, cmp)
     }
 }
 
-impl<I, J, F> Iterator for MergeBy<I, J, F> where
-    I: Iterator,
-    J: Iterator<Item=I::Item>,
-    F: FnMut(&I::Item, &I::Item) -> bool
+impl<I, J, F> Iterator for MergeBy<I, J, F>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>,
+          F: FnMut(&I::Item, &I::Item) -> bool
 {
     type Item = I::Item;
 
@@ -697,20 +704,25 @@ impl<I, J, F> Iterator for MergeBy<I, J, F> where
 ///
 /// The meanings of `PartialOrd` and `Ord` are reversed so as to turn the `BinaryHeap` used in
 /// `KMerge` into a min-heap.
-struct NonEmpty<I> where
-    I: Iterator
+struct NonEmpty<I>
+    where I: Iterator
 {
     head: I::Item,
     tail: I,
 }
 
-impl<I> NonEmpty<I> where
-    I: Iterator,
+impl<I> NonEmpty<I>
+    where I: Iterator
 {
     /// Constructs a `NonEmpty` from an `Iterator`. Returns `None` if the `Iterator` is empty.
     fn new(mut it: I) -> Option<NonEmpty<I>> {
         let head = it.next();
-        head.map(|h| NonEmpty { head: h, tail: it })
+        head.map(|h| {
+            NonEmpty {
+                head: h,
+                tail: it,
+            }
+        })
     }
 
     /// Returns the next item in the sequence. If more items remain, the remainder of the sequence
@@ -725,32 +737,32 @@ impl<I> NonEmpty<I> where
     }
 }
 
-impl<I> Clone for NonEmpty<I> where
-    I: Iterator + Clone,
-    I::Item: Clone
+impl<I> Clone for NonEmpty<I>
+    where I: Iterator + Clone,
+          I::Item: Clone
 {
     fn clone(&self) -> Self {
         clone_fields!(NonEmpty, self, head, tail)
     }
 }
 
-impl<I> PartialEq for NonEmpty<I> where
-    I: Iterator,
-    I::Item: PartialEq
+impl<I> PartialEq for NonEmpty<I>
+    where I: Iterator,
+          I::Item: PartialEq
 {
     fn eq(&self, other: &NonEmpty<I>) -> bool {
         self.head.eq(&other.head)
     }
 }
 
-impl<I> Eq for NonEmpty<I> where
-    I: Iterator,
-    I::Item: Eq
-{ }
+impl<I> Eq for NonEmpty<I>
+    where I: Iterator,
+          I::Item: Eq
+{}
 
-impl<I> PartialOrd for NonEmpty<I> where
-    I: Iterator,
-    I::Item: PartialOrd
+impl<I> PartialOrd for NonEmpty<I>
+    where I: Iterator,
+          I::Item: PartialOrd
 {
     fn partial_cmp(&self, other: &NonEmpty<I>) -> Option<Ordering> {
         other.head.partial_cmp(&self.head)
@@ -773,9 +785,9 @@ impl<I> PartialOrd for NonEmpty<I> where
     }
 }
 
-impl<I> Ord for NonEmpty<I> where
-    I: Iterator,
-    I::Item: Ord
+impl<I> Ord for NonEmpty<I>
+    where I: Iterator,
+          I::Item: Ord
 {
     fn cmp(&self, other: &Self) -> Ordering {
         other.head.cmp(&self.head)
@@ -788,8 +800,8 @@ impl<I> Ord for NonEmpty<I> where
 /// Iterator element type is `I::Item`.
 ///
 /// See [*.kmerge()*](trait.Itertools.html#method.kmerge) for more information.
-pub struct KMerge<I> where
-    I: Iterator
+pub struct KMerge<I>
+    where I: Iterator
 {
     heap: BinaryHeap<NonEmpty<I>>,
 }
@@ -800,23 +812,21 @@ pub fn kmerge_new<I>(it: I) -> KMerge<<I::Item as IntoIterator>::IntoIter>
           I::Item: IntoIterator,
           <<I as Iterator>::Item as IntoIterator>::Item: Ord
 {
-    KMerge {
-        heap: it.filter_map(|it| NonEmpty::new(it.into_iter())).collect()
-    }
+    KMerge { heap: it.filter_map(|it| NonEmpty::new(it.into_iter())).collect() }
 }
 
-impl<I> Clone for KMerge<I> where
-    I: Iterator + Clone,
-    I::Item: Clone
+impl<I> Clone for KMerge<I>
+    where I: Iterator + Clone,
+          I::Item: Clone
 {
     fn clone(&self) -> KMerge<I> {
         clone_fields!(KMerge, self, heap)
     }
 }
 
-impl<I> Iterator for KMerge<I> where
-    I: Iterator,
-    I::Item: Ord
+impl<I> Iterator for KMerge<I>
+    where I: Iterator,
+          I::Item: Ord
 {
     type Item = I::Item;
 
@@ -844,31 +854,31 @@ impl<I> Iterator for KMerge<I> where
 /// with a custom starting value and integer type.
 ///
 /// See [*.enumerate_from()*](trait.Itertools.html#method.enumerate_from) for more information.
-pub struct EnumerateFrom<I, K>
-{
+pub struct EnumerateFrom<I, K> {
     index: K,
     iter: I,
 }
 
 #[cfg(feature = "unstable")]
-impl<K, I> EnumerateFrom<I, K> where
-    I: Iterator,
+impl<K, I> EnumerateFrom<I, K>
+    where I: Iterator
 {
     /// Create a new `EnumerateFrom`.
-    pub fn new(iter: I, start: K) -> Self
-    {
-        EnumerateFrom{index: start, iter: iter}
+    pub fn new(iter: I, start: K) -> Self {
+        EnumerateFrom {
+            index: start,
+            iter: iter,
+        }
     }
 }
 
 #[cfg(feature = "unstable")]
-impl<K, I> Iterator for EnumerateFrom<I, K> where
-    K: Copy + One + Add<Output=K>,
-    I: Iterator,
+impl<K, I> Iterator for EnumerateFrom<I, K>
+    where K: Copy + One + Add<Output = K>,
+          I: Iterator
 {
     type Item = (K, I::Item);
-    fn next(&mut self) -> Option<(K, I::Item)>
-    {
+    fn next(&mut self) -> Option<(K, I::Item)> {
         match self.iter.next() {
             None => None,
             Some(elt) => {
@@ -881,26 +891,25 @@ impl<K, I> Iterator for EnumerateFrom<I, K> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 }
 
 // Same size
 #[cfg(feature = "unstable")]
-impl<K, I> ExactSizeIterator for EnumerateFrom<I, K> where
-    K: Copy + One + Add<Output=K>,
-    I: ExactSizeIterator,
-{ }
+impl<K, I> ExactSizeIterator for EnumerateFrom<I, K>
+    where K: Copy + One + Add<Output = K>,
+          I: ExactSizeIterator
+{}
 
 #[derive(Clone)]
 /// An iterator adaptor that allows the user to peek at multiple *.next()*
 /// values without advancing itself.
 ///
 /// See [*.multipeek()*](trait.Itertools.html#method.multipeek) for more information.
-pub struct MultiPeek<I> where
-    I: Iterator,
+pub struct MultiPeek<I>
+    where I: Iterator
 {
     iter: Fuse<I>,
     buf: Vec<I::Item>,
@@ -910,7 +919,11 @@ pub struct MultiPeek<I> where
 impl<I: Iterator> MultiPeek<I> {
     /// Create a `MultiPeek` iterator.
     pub fn new(iter: I) -> MultiPeek<I> {
-        MultiPeek{ iter: iter.fuse(), buf: Vec::new(), index: 0 }
+        MultiPeek {
+            iter: iter.fuse(),
+            buf: Vec::new(),
+            index: 0,
+        }
     }
 
     /// Works exactly like *.next()* with the only difference that it doesn't
@@ -925,7 +938,7 @@ impl<I: Iterator> MultiPeek<I> {
                     self.buf.push(x);
                     Some(&self.buf[self.index])
                 }
-                None => return None
+                None => return None,
             }
         };
 
@@ -934,8 +947,8 @@ impl<I: Iterator> MultiPeek<I> {
     }
 }
 
-impl<I> Iterator for MultiPeek<I> where
-    I: Iterator,
+impl<I> Iterator for MultiPeek<I>
+    where I: Iterator
 {
     type Item = I::Item;
 
@@ -948,27 +961,26 @@ impl<I> Iterator for MultiPeek<I> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         size_hint::add_scalar(self.iter.size_hint(), self.buf.len())
     }
 }
 
 // Same size
-impl<I> ExactSizeIterator for MultiPeek<I> where
-    I: ExactSizeIterator,
-{ }
+impl<I> ExactSizeIterator for MultiPeek<I>
+    where I: ExactSizeIterator
+{}
 
 #[derive(Clone)]
 pub struct CoalesceCore<I>
-    where I: Iterator,
+    where I: Iterator
 {
     iter: I,
     last: Option<I::Item>,
 }
 
 impl<I> CoalesceCore<I>
-    where I: Iterator,
+    where I: Iterator
 {
     fn next_with<F>(&mut self, mut f: F) -> Option<I::Item>
         where F: FnMut(I::Item, I::Item) -> Result<I::Item, (I::Item, I::Item)>
@@ -983,7 +995,7 @@ impl<I> CoalesceCore<I>
                 Ok(joined) => last = joined,
                 Err((last_, next_)) => {
                     self.last = Some(next_);
-                    return Some(last_)
+                    return Some(last_);
                 }
             }
         }
@@ -991,8 +1003,7 @@ impl<I> CoalesceCore<I>
         Some(last)
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let (low, hi) = size_hint::add_scalar(self.iter.size_hint(),
                                               self.last.is_some() as usize);
         ((low > 0) as usize, hi)
@@ -1003,22 +1014,23 @@ impl<I> CoalesceCore<I>
 ///
 /// See [*.coalesce()*](trait.Itertools.html#method.coalesce) for more information.
 pub struct Coalesce<I, F>
-    where I: Iterator,
+    where I: Iterator
 {
     iter: CoalesceCore<I>,
     f: F,
 }
 
 impl<I: Clone, F: Clone> Clone for Coalesce<I, F>
-    where I: Iterator, I::Item: Clone
+    where I: Iterator,
+          I::Item: Clone
 {
     fn clone(&self) -> Self {
         clone_fields!(Coalesce, self, iter, f)
     }
 }
 
-impl<I, F> Coalesce<I, F> where
-    I: Iterator,
+impl<I, F> Coalesce<I, F>
+    where I: Iterator
 {
     /// Create a new `Coalesce`.
     pub fn new(mut iter: I, f: F) -> Self {
@@ -1051,21 +1063,22 @@ impl<I, F> Iterator for Coalesce<I, F>
 ///
 /// See [*.dedup()*](trait.Itertools.html#method.dedup) for more information.
 pub struct Dedup<I>
-    where I: Iterator,
+    where I: Iterator
 {
     iter: CoalesceCore<I>,
 }
 
 impl<I: Clone> Clone for Dedup<I>
-    where I: Iterator, I::Item: Clone
+    where I: Iterator,
+          I::Item: Clone
 {
     fn clone(&self) -> Self {
         clone_fields!(Dedup, self, iter)
     }
 }
 
-impl<I> Dedup<I> where
-    I: Iterator,
+impl<I> Dedup<I>
+    where I: Iterator
 {
     /// Create a new `Dedup`.
     pub fn new(mut iter: I) -> Self {
@@ -1080,7 +1093,7 @@ impl<I> Dedup<I> where
 
 impl<I> Iterator for Dedup<I>
     where I: Iterator,
-          I::Item: PartialEq,
+          I::Item: PartialEq
 {
     type Item = I::Item;
 
@@ -1099,21 +1112,22 @@ impl<I> Iterator for Dedup<I>
 ///
 /// See [*.mend_slices()*](trait.Itertools.html#method.mend_slices) for more information.
 pub struct MendSlices<I>
-    where I: Iterator,
+    where I: Iterator
 {
     iter: CoalesceCore<I>,
 }
 
 impl<I: Clone> Clone for MendSlices<I>
-    where I: Iterator, I::Item: Clone
+    where I: Iterator,
+          I::Item: Clone
 {
     fn clone(&self) -> Self {
         clone_fields!(MendSlices, self, iter)
     }
 }
 
-impl<I> MendSlices<I> where
-    I: Iterator,
+impl<I> MendSlices<I>
+    where I: Iterator
 {
     /// Create a new `MendSlices`.
     pub fn new(mut iter: I) -> Self {
@@ -1128,7 +1142,7 @@ impl<I> MendSlices<I> where
 
 impl<I> Iterator for MendSlices<I>
     where I: Iterator,
-          I::Item: MendSlice,
+          I::Item: MendSlice
 {
     type Item = I::Item;
 
@@ -1145,32 +1159,27 @@ impl<I> Iterator for MendSlices<I>
 /// to only pick off elements while the predicate returns `true`.
 ///
 /// See [*.take_while_ref()*](trait.Itertools.html#method.take_while_ref) for more information.
-pub struct TakeWhileRef<'a, I: 'a, F>
-{
+pub struct TakeWhileRef<'a, I: 'a, F> {
     iter: &'a mut I,
     f: F,
 }
 
-impl<'a, I, F> TakeWhileRef<'a, I, F> where I: Iterator + Clone,
+impl<'a, I, F> TakeWhileRef<'a, I, F>
+    where I: Iterator + Clone
 {
     /// Create a new `TakeWhileRef` from a reference to clonable iterator.
-    pub fn new(iter: &'a mut I, f: F) -> Self
-    {
-        TakeWhileRef {
-            iter: iter,
-            f: f,
-        }
+    pub fn new(iter: &'a mut I, f: F) -> Self {
+        TakeWhileRef { iter: iter, f: f }
     }
 }
 
-impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F> where
-    I: Iterator + Clone,
-    F: FnMut(&I::Item) -> bool,
+impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F>
+    where I: Iterator + Clone,
+          F: FnMut(&I::Item) -> bool
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item>
-    {
+    fn next(&mut self) -> Option<I::Item> {
         let old = self.iter.clone();
         match self.iter.next() {
             None => None,
@@ -1185,8 +1194,7 @@ impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let (_, hi) = self.iter.size_hint();
         (0, hi)
     }
@@ -1208,8 +1216,8 @@ impl<I> WhileSome<I> {
     }
 }
 
-impl<I, A> Iterator for WhileSome<I> where
-    I: Iterator<Item=Option<A>>
+impl<I, A> Iterator for WhileSome<I>
+    where I: Iterator<Item = Option<A>>
 {
     type Item = A;
 
@@ -1235,18 +1243,23 @@ pub struct Combinations<I: Iterator> {
     next_iter: I,
     val: Option<I::Item>,
 }
-impl<I> Combinations<I> where I: Iterator + Clone {
+impl<I> Combinations<I>
+    where I: Iterator + Clone
+{
     /// Create a new `Combinations` from a clonable iterator.
     pub fn new(iter: I) -> Combinations<I> {
-        Combinations { 
-            next_iter: iter.clone(), 
-            iter: iter, 
+        Combinations {
+            next_iter: iter.clone(),
+            iter: iter,
             val: None,
         }
     }
 }
 
-impl<I> Iterator for Combinations<I> where I: Iterator + Clone, I::Item: Clone {
+impl<I> Iterator for Combinations<I>
+    where I: Iterator + Clone,
+          I::Item: Clone
+{
     type Item = (I::Item, I::Item);
     fn next(&mut self) -> Option<Self::Item> {
         // not having a value means we iterate once more through the first iterator
@@ -1291,7 +1304,9 @@ struct LazyBuffer<I: Iterator> {
     buffer: Vec<I::Item>,
 }
 
-impl<I> LazyBuffer<I> where I: Iterator {
+impl<I> LazyBuffer<I>
+    where I: Iterator
+{
     pub fn new(it: I) -> LazyBuffer<I> {
         let mut it = it;
         let mut buffer = Vec::new();
@@ -1326,16 +1341,19 @@ impl<I> LazyBuffer<I> where I: Iterator {
             Some(x) => {
                 self.buffer.push(x);
                 true
-            },
+            }
             None => {
                 self.done = true;
                 false
-            },
+            }
         }
     }
 }
 
-impl<I> Index<usize> for LazyBuffer<I> where I: Iterator, I::Item: Sized {
+impl<I> Index<usize> for LazyBuffer<I>
+    where I: Iterator,
+          I::Item: Sized
+{
     type Output = I::Item;
 
     fn index<'b>(&'b self, _index: usize) -> &'b I::Item {
@@ -1352,7 +1370,9 @@ pub struct CombinationsN<I: Iterator> {
     pool: LazyBuffer<I>,
     first: bool,
 }
-impl<I> CombinationsN<I> where I: Iterator {
+impl<I> CombinationsN<I>
+    where I: Iterator
+{
     /// Create a new `CombinationsN` from a clonable iterator.
     pub fn new(iter: I, n: usize) -> CombinationsN<I> {
         let mut indices: Vec<usize> = Vec::with_capacity(n);
@@ -1376,7 +1396,10 @@ impl<I> CombinationsN<I> where I: Iterator {
     }
 }
 
-impl<I> Iterator for CombinationsN<I> where I: Iterator, I::Item: Clone {
+impl<I> Iterator for CombinationsN<I>
+    where I: Iterator,
+          I::Item: Clone
+{
     type Item = Vec<I::Item>;
     fn next(&mut self) -> Option<Self::Item> {
         let mut pool_len = self.pool.len();
@@ -1412,7 +1435,7 @@ impl<I> Iterator for CombinationsN<I> where I: Iterator, I::Item: Clone {
             self.indices[i] += 1;
             let mut j = i + 1;
             while j < self.n {
-                self.indices[j] = self.indices[j-1] + 1;
+                self.indices[j] = self.indices[j - 1] + 1;
                 j += 1;
             }
         }
@@ -1450,10 +1473,10 @@ impl<I: Iterator, V, F> UniqueBy<I, V, F>
     }
 }
 
-impl<I, V, F> Iterator for UniqueBy<I, V, F> where
-    I: Iterator,
-    V: Eq + Hash,
-    F: FnMut(&I::Item) -> V
+impl<I, V, F> Iterator for UniqueBy<I, V, F>
+    where I: Iterator,
+          V: Eq + Hash,
+          F: FnMut(&I::Item) -> V
 {
     type Item = I::Item;
 
@@ -1478,9 +1501,9 @@ impl<I, V, F> Iterator for UniqueBy<I, V, F> where
     }
 }
 
-impl<I> Iterator for Unique<I> where
-    I: Iterator,
-    I::Item: Eq + Hash + Clone,
+impl<I> Iterator for Unique<I>
+    where I: Iterator,
+          I::Item: Eq + Hash + Clone
 {
     type Item = I::Item;
 
@@ -1532,27 +1555,27 @@ pub fn unique<I>(iter: I) -> Unique<I>
 /// See [*.flatten()*](trait.Itertools.html#method.flatten) for more information.
 pub struct Flatten<I>
     where I: Iterator,
-          I::Item: IntoIterator,
+          I::Item: IntoIterator
 {
-    iter: FlatMap<I, I::Item, fn(I::Item) -> I::Item>
+    iter: FlatMap<I, I::Item, fn(I::Item) -> I::Item>,
 }
 
-impl<I> Flatten<I> where
-    I: Iterator,
-    I::Item: IntoIterator
+impl<I> Flatten<I>
+    where I: Iterator,
+          I::Item: IntoIterator
 {
     /// Create a new `Flatten` iterator.
     pub fn new(iter: I) -> Flatten<I> {
-        fn identity<T>(t: T) -> T { t }
-        Flatten {
-            iter: iter.flat_map(identity)
+        fn identity<T>(t: T) -> T {
+            t
         }
+        Flatten { iter: iter.flat_map(identity) }
     }
 }
 
-impl<I> Iterator for Flatten<I> where
-    I: Iterator,
-    I::Item: IntoIterator
+impl<I> Iterator for Flatten<I>
+    where I: Iterator,
+          I::Item: IntoIterator
 {
     type Item = <I::Item as IntoIterator>::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -1562,7 +1585,7 @@ impl<I> Iterator for Flatten<I> where
 
 impl<I> DoubleEndedIterator for Flatten<I>
     where I: DoubleEndedIterator,
-          I::Item: DoubleEndedIterator,
+          I::Item: DoubleEndedIterator
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -13,7 +13,7 @@ use adaptors::PutBack;
 /// iterator `J`.
 pub enum Diff<I, J>
     where I: Iterator,
-          J: Iterator,
+          J: Iterator
 {
     /// The index of the first non-matching element along with both iterator's remaining elements
     /// starting with the first mis-match.
@@ -36,10 +36,11 @@ pub enum Diff<I, J>
 ///
 /// If `i` becomes exhausted before `j` becomes exhausted, the number of elements in `i` along with
 /// the remaining `j` elements will be returned as `Diff::Longer`.
-pub fn diff_with<I, J, F>(i: I, j: J, is_equal: F) -> Option<Diff<I::IntoIter, J::IntoIter>>
+pub fn diff_with<I, J, F>(i: I, j: J, is_equal: F)
+    -> Option<Diff<I::IntoIter, J::IntoIter>>
     where I: IntoIterator,
           J: IntoIterator,
-          F: Fn(&I::Item, &J::Item) -> bool,
+          F: Fn(&I::Item, &J::Item) -> bool
 {
     let mut i = i.into_iter();
     let mut j = j.into_iter();

--- a/src/format.rs
+++ b/src/format.rs
@@ -12,19 +12,22 @@ pub struct Format<'a, I, F> {
 
 pub fn new_format<'a, I, F>(iter: I, separator: &'a str, f: F) -> Format<'a, I, F>
     where I: Iterator,
-          F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result,
+          F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result
 {
-    Format{sep: separator, inner: RefCell::new((iter, f))}
+    Format {
+        sep: separator,
+        inner: RefCell::new((iter, f)),
+    }
 }
 
 impl<'a, I, F> fmt::Display for Format<'a, I, F>
     where I: Iterator,
-          F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result,
+          F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut cb = &mut |disp: &fmt::Display| write!(fmt, "{}", disp);
         // the extra *&mut is a workaround for Rust 1.0
-        let (ref mut iter, ref mut format)  = *&mut *self.inner.borrow_mut();
+        let (ref mut iter, ref mut format) = *&mut *self.inner.borrow_mut();
 
         if let Some(fst) = iter.next() {
             try!(format(fst, cb));

--- a/src/free.rs
+++ b/src/free.rs
@@ -24,7 +24,7 @@ use {
 /// }
 /// ```
 pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
-    where I: IntoIterator,
+    where I: IntoIterator
 {
     iterable.into_iter().enumerate()
 }
@@ -42,7 +42,7 @@ pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 /// ```
 pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
     where I: IntoIterator,
-          I::IntoIter: DoubleEndedIterator,
+          I::IntoIter: DoubleEndedIterator
 {
     iterable.into_iter().rev()
 }
@@ -61,7 +61,7 @@ pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
 /// ```
 pub fn zip<I, J>(i: I, j: J) -> Zip<I::IntoIter, J::IntoIter>
     where I: IntoIterator,
-          J: IntoIterator,
+          J: IntoIterator
 {
     i.into_iter().zip(j)
 }
@@ -79,7 +79,7 @@ pub fn zip<I, J>(i: I, j: J) -> Zip<I::IntoIter, J::IntoIter>
 /// ```
 pub fn chain<I, J>(i: I, j: J) -> iter::Chain<I::IntoIter, J::IntoIter>
     where I: IntoIterator,
-          J: IntoIterator<Item=I::Item>,
+          J: IntoIterator<Item = I::Item>
 {
     i.into_iter().chain(j)
 }
@@ -95,7 +95,7 @@ pub fn chain<I, J>(i: I, j: J) -> iter::Chain<I::IntoIter, J::IntoIter>
 /// ```
 pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
     where I: IntoIterator,
-          F: FnMut(B, I::Item) -> B,
+          F: FnMut(B, I::Item) -> B
 {
     iterable.into_iter().fold(init, f)
 }
@@ -111,7 +111,7 @@ pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
 /// ```
 pub fn all<I, F>(iterable: I, f: F) -> bool
     where I: IntoIterator,
-          F: FnMut(I::Item) -> bool,
+          F: FnMut(I::Item) -> bool
 {
     iterable.into_iter().all(f)
 }
@@ -127,7 +127,7 @@ pub fn all<I, F>(iterable: I, f: F) -> bool
 /// ```
 pub fn any<I, F>(iterable: I, f: F) -> bool
     where I: IntoIterator,
-          F: FnMut(I::Item) -> bool,
+          F: FnMut(I::Item) -> bool
 {
     iterable.into_iter().any(f)
 }
@@ -143,7 +143,7 @@ pub fn any<I, F>(iterable: I, f: F) -> bool
 /// ```
 pub fn max<I>(iterable: I) -> Option<I::Item>
     where I: IntoIterator,
-          I::Item: Ord,
+          I::Item: Ord
 {
     iterable.into_iter().max()
 }
@@ -159,7 +159,7 @@ pub fn max<I>(iterable: I) -> Option<I::Item>
 /// ```
 pub fn min<I>(iterable: I) -> Option<I::Item>
     where I: IntoIterator,
-          I::Item: Ord,
+          I::Item: Ord
 {
     iterable.into_iter().min()
 }
@@ -177,7 +177,7 @@ pub fn min<I>(iterable: I) -> Option<I::Item>
 /// ```
 pub fn interleave<I, J>(i: I, j: J) -> Interleave<I::IntoIter, J::IntoIter>
     where I: IntoIterator,
-          J: IntoIterator<Item=I::Item>,
+          J: IntoIterator<Item = I::Item>
 {
     i.into_iter().interleave(j)
 }
@@ -195,8 +195,8 @@ pub fn interleave<I, J>(i: I, j: J) -> Interleave<I::IntoIter, J::IntoIter>
 /// ```
 pub fn merge<I, J>(i: I, j: J) -> Merge<I::IntoIter, J::IntoIter>
     where I: IntoIterator,
-          J: IntoIterator<Item=I::Item>,
-          I::Item: PartialOrd,
+          J: IntoIterator<Item = I::Item>,
+          I::Item: PartialOrd
 {
     i.into_iter().merge(j)
 }
@@ -231,7 +231,7 @@ pub fn kmerge<I>(i: I) -> KMerge<<<I as IntoIterator>::Item as IntoIterator>::In
 /// ```
 pub fn join<I>(iterable: I, sep: &str) -> String
     where I: IntoIterator,
-          I::Item: Display,
+          I::Item: Display
 {
     iterable.into_iter().join(sep)
 }
@@ -248,7 +248,7 @@ pub fn join<I>(iterable: I, sep: &str) -> String
 /// ```
 pub fn sorted<I>(iterable: I) -> Vec<I::Item>
     where I: IntoIterator,
-          I::Item: Ord,
+          I::Item: Ord
 {
     iterable.into_iter().sorted()
 }

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -8,7 +8,9 @@ trait KeyFunction<A> {
     fn call_mut(&mut self, arg: A) -> Self::Key;
 }
 
-impl<'a, A, K, F: ?Sized> KeyFunction<A> for F where F: FnMut(A) -> K {
+impl<'a, A, K, F: ?Sized> KeyFunction<A> for F
+    where F: FnMut(A) -> K
+{
     type Key = K;
     #[inline]
     fn call_mut(&mut self, arg: A) -> Self::Key {
@@ -50,7 +52,7 @@ impl<'a, A> KeyFunction<A> for ChunkIndex {
 
 
 struct GroupInner<K, I, F>
-    where I: Iterator,
+    where I: Iterator
 {
     key: F,
     iter: I,
@@ -104,7 +106,7 @@ impl<K, I, F> GroupInner<K, I, F>
         // if `bufidx` doesn't exist in self.buffer, it might be empty
         let bufidx = client - self.bufbot;
         if client < self.bot {
-            return None
+            return None;
         }
         let elt = self.buffer.get_mut(bufidx).and_then(|queue| queue.next());
         if elt.is_none() && client == self.bot {
@@ -332,15 +334,13 @@ impl<'a, K, I, F> IntoIterator for &'a GroupByLazy<K, I, F>
     where I: Iterator,
           I::Item: 'a,
           F: FnMut(&I::Item) -> K,
-          K: PartialEq,
+          K: PartialEq
 {
     type Item = (K, Group<'a, K, I, F>);
     type IntoIter = Groups<'a, K, I, F>;
 
     fn into_iter(self) -> Self::IntoIter {
-        Groups {
-            parent: self,
-        }
+        Groups { parent: self }
     }
 }
 
@@ -353,7 +353,7 @@ impl<'a, K, I, F> IntoIterator for &'a GroupByLazy<K, I, F>
 /// See [`.group_by_lazy()`](trait.Itertools.html#method.group_by_lazy) for more information.
 pub struct Groups<'a, K: 'a, I: 'a, F: 'a>
     where I: Iterator,
-          I::Item: 'a,
+          I::Item: 'a
 {
     parent: &'a GroupByLazy<K, I, F>,
 }
@@ -362,7 +362,7 @@ impl<'a, K, I, F> Iterator for Groups<'a, K, I, F>
     where I: Iterator,
           I::Item: 'a,
           F: FnMut(&I::Item) -> K,
-          K: PartialEq,
+          K: PartialEq
 {
     type Item = (K, Group<'a, K, I, F>);
 

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -10,33 +10,35 @@ use super::size_hint;
 /// This iterator is *fused*.
 ///
 /// See [*.intersperse()*](trait.Itertools.html#method.intersperse) for more information.
-pub struct Intersperse<I> where
-    I: Iterator,
+pub struct Intersperse<I>
+    where I: Iterator
 {
     element: I::Item,
     iter: Fuse<I>,
     peek: Option<I::Item>,
 }
 
-impl<I> Intersperse<I> where
-    I: Iterator,
+impl<I> Intersperse<I>
+    where I: Iterator
 {
     /// Create a new Intersperse iterator
-    pub fn new(iter: I, elt: I::Item) -> Self
-    {
+    pub fn new(iter: I, elt: I::Item) -> Self {
         let mut iter = iter.fuse();
-        Intersperse{peek: iter.next(), iter: iter, element: elt}
+        Intersperse {
+            peek: iter.next(),
+            iter: iter,
+            element: elt,
+        }
     }
 }
 
-impl<I> Iterator for Intersperse<I> where
-    I: Iterator,
-    I::Item: Clone,
+impl<I> Iterator for Intersperse<I>
+    where I: Iterator,
+          I::Item: Clone
 {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item>
-    {
+    fn next(&mut self) -> Option<I::Item> {
         if self.peek.is_some() {
             self.peek.take()
         } else {
@@ -49,12 +51,10 @@ impl<I> Iterator for Intersperse<I> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         // 2 * SH + { 1 or 0 }
         let has_peek = self.peek.is_some() as usize;
         let sh = self.iter.size_hint();
-        size_hint::add_scalar(
-            size_hint::add(sh, sh), has_peek)
+        size_hint::add_scalar(size_hint::add(sh, sh), has_peek)
     }
 }

--- a/src/islice.rs
+++ b/src/islice.rs
@@ -27,8 +27,7 @@ impl<I> ISlice<I>
     where I: Iterator
 {
     /// Create a new **ISlice**.
-    pub fn new<R: GenericRange>(iter: I, range: R) -> Self
-    {
+    pub fn new<R: GenericRange>(iter: I, range: R) -> Self {
         let mut start = range.start().unwrap_or(0);
         let end = range.end().unwrap_or(::std::usize::MAX);
         if start > end {
@@ -55,7 +54,7 @@ impl<I> Iterator for ISlice<I>
             self.end -= n;
             if n != st {
                 // iterator is already done.
-                return None
+                return None;
             }
         }
         if self.end != 0 {
@@ -66,8 +65,7 @@ impl<I> Iterator for ISlice<I>
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.end - self.start;
         let sh = self.iter.size_hint();
         size_hint::min(size_hint::sub_scalar(sh, self.start), (len, Some(len)))
@@ -76,4 +74,4 @@ impl<I> Iterator for ISlice<I>
 
 impl<I> ExactSizeIterator for ISlice<I>
     where I: ExactSizeIterator
-{ }
+{}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use free::{enumerate, rev};
 pub use format::Format;
 pub use groupbylazy::{ChunksLazy, Chunk, Chunks, GroupByLazy, Group, Groups};
 pub use intersperse::Intersperse;
-pub use islice::{ISlice};
+pub use islice::ISlice;
 pub use pad_tail::PadUsing;
 pub use repeatn::RepeatN;
 pub use rciter::RcIter;
@@ -80,12 +80,9 @@ pub use stride::Stride;
 pub use stride::StrideMut;
 pub use tee::Tee;
 pub use linspace::{linspace, Linspace};
-pub use sources::{
-    RepeatCall,
-    Unfold,
-};
+pub use sources::{RepeatCall, Unfold};
 pub use zip_longest::{ZipLongest, EitherOrBoth};
-pub use ziptuple::{Zip};
+pub use ziptuple::Zip;
 #[cfg(feature = "unstable")]
 pub use ziptrusted::{ZipTrusted, TrustedIterator};
 pub use zipslices::ZipSlices;
@@ -211,9 +208,9 @@ pub trait Itertools : Iterator {
     /// let it = (0..3).interleave(vec![7, 8]);
     /// itertools::assert_equal(it, vec![0, 7, 1, 8, 2]);
     /// ```
-    fn interleave<J>(self, other: J) -> Interleave<Self, J::IntoIter> where
-        J: IntoIterator<Item=Self::Item>,
-        Self: Sized
+    fn interleave<J>(self, other: J) -> Interleave<Self, J::IntoIter>
+        where J: IntoIterator<Item = Self::Item>,
+              Self: Sized
     {
         Interleave::new(self, other.into_iter())
     }
@@ -228,9 +225,9 @@ pub trait Itertools : Iterator {
     /// let it = (0..5).interleave_shortest(vec![7, 8]);
     /// itertools::assert_equal(it, vec![0, 7, 1, 8, 2]);
     /// ```
-    fn interleave_shortest<J>(self, other: J) -> InterleaveShortest<Self, J::IntoIter> where
-        J: IntoIterator<Item=Self::Item>,
-        Self: Sized
+    fn interleave_shortest<J>(self, other: J) -> InterleaveShortest<Self, J::IntoIter>
+        where J: IntoIterator<Item = Self::Item>,
+              Self: Sized
     {
         InterleaveShortest::new(self, other.into_iter())
     }
@@ -247,9 +244,9 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal((0..3).intersperse(8), vec![0, 8, 1, 8, 2]);
     /// ```
-    fn intersperse(self, element: Self::Item) -> Intersperse<Self> where
-        Self: Sized,
-        Self::Item: Clone
+    fn intersperse(self, element: Self::Item) -> Intersperse<Self>
+        where Self: Sized,
+              Self::Item: Clone
     {
         Intersperse::new(self, element)
     }
@@ -272,9 +269,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![Both(0, 1), Right(2)]);
     /// ```
     #[inline]
-    fn zip_longest<J>(self, other: J) -> ZipLongest<Self, J::IntoIter> where
-        J: IntoIterator,
-        Self: Sized,
+    fn zip_longest<J>(self, other: J) -> ZipLongest<Self, J::IntoIter>
+        where J: IntoIterator,
+              Self: Sized
     {
         ZipLongest::new(self, other.into_iter())
     }
@@ -301,9 +298,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(pit, vec![(0, 1), (2, 3)]);
     /// ```
     ///
-    fn batching<B, F>(self, f: F) -> Batching<Self, F> where
-        F: FnMut(&mut Self) -> Option<B>,
-        Self: Sized,
+    fn batching<B, F>(self, f: F) -> Batching<Self, F>
+        where F: FnMut(&mut Self) -> Option<B>,
+              Self: Sized
     {
         Batching::new(self, f)
     }
@@ -429,9 +426,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(t1.next(), None);
     /// assert_eq!(t2.next(), Some(1));
     /// ```
-    fn tee(self) -> (Tee<Self>, Tee<Self>) where
-        Self: Sized,
-        Self::Item: Clone
+    fn tee(self) -> (Tee<Self>, Tee<Self>)
+        where Self: Sized,
+              Self::Item: Clone
     {
         tee::new(self)
     }
@@ -450,9 +447,9 @@ pub trait Itertools : Iterator {
     /// let it = repeat('a').slice(..3);
     /// assert_eq!(it.count(), 3);
     /// ```
-    fn slice<R>(self, range: R) -> ISlice<Self> where
-        R: misc::GenericRange,
-        Self: Sized,
+    fn slice<R>(self, range: R) -> ISlice<Self>
+        where R: misc::GenericRange,
+              Self: Sized
     {
         ISlice::new(self, range)
     }
@@ -484,8 +481,8 @@ pub trait Itertools : Iterator {
     /// **Panics** in iterator methods if a borrow error is encountered,
     /// but it can only happen if the `RcIter` is reentered in for example `.next()`,
     /// i.e. if it somehow participates in an “iterator knot” where it is an adaptor of itself.
-    fn into_rc(self) -> RcIter<Self> where
-        Self: Sized,
+    fn into_rc(self) -> RcIter<Self>
+        where Self: Sized
     {
         RcIter::new(self)
     }
@@ -506,8 +503,8 @@ pub trait Itertools : Iterator {
     /// let it = (0..8).step(3);
     /// itertools::assert_equal(it, vec![0, 3, 6]);
     /// ```
-    fn step(self, n: usize) -> Step<Self> where
-        Self: Sized,
+    fn step(self, n: usize) -> Step<Self>
+        where Self: Sized
     {
         Step::new(self, n)
     }
@@ -525,10 +522,10 @@ pub trait Itertools : Iterator {
     /// let it = a.merge(b);
     /// itertools::assert_equal(it, vec![0, 0, 3, 5, 6, 9, 10]);
     /// ```
-    fn merge<J>(self, other: J) -> Merge<Self, J::IntoIter> where
-        Self: Sized,
-        Self::Item: PartialOrd,
-        J: IntoIterator<Item=Self::Item>,
+    fn merge<J>(self, other: J) -> Merge<Self, J::IntoIter>
+        where Self: Sized,
+              Self::Item: PartialOrd,
+              J: IntoIterator<Item = Self::Item>
     {
         adaptors::merge_new(self, other.into_iter())
     }
@@ -549,10 +546,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(0, 'a'), (0, 'b'), (1, 'c'), (1, 'd')]);
     /// ```
 
-    fn merge_by<J, F>(self, other: J, is_first: F) -> MergeBy<Self, J::IntoIter, F> where
-        Self: Sized,
-        J: IntoIterator<Item=Self::Item>,
-        F: FnMut(&Self::Item, &Self::Item) -> bool
+    fn merge_by<J, F>(self, other: J, is_first: F) -> MergeBy<Self, J::IntoIter, F>
+        where Self: Sized,
+              J: IntoIterator<Item = Self::Item>,
+              F: FnMut(&Self::Item, &Self::Item) -> bool
     {
         adaptors::merge_by_new(self, other.into_iter(), is_first)
     }
@@ -592,11 +589,11 @@ pub trait Itertools : Iterator {
     /// let it = (0..2).cartesian_product("αβ".chars());
     /// itertools::assert_equal(it, vec![(0, 'α'), (0, 'β'), (1, 'α'), (1, 'β')]);
     /// ```
-    fn cartesian_product<J>(self, other: J) -> Product<Self, J::IntoIter> where
-        Self: Sized,
-        Self::Item: Clone,
-        J: IntoIterator,
-        J::IntoIter: Clone,
+    fn cartesian_product<J>(self, other: J) -> Product<Self, J::IntoIter>
+        where Self: Sized,
+              Self::Item: Clone,
+              J: IntoIterator,
+              J::IntoIter: Clone
     {
         Product::new(self, other.into_iter())
     }
@@ -615,8 +612,8 @@ pub trait Itertools : Iterator {
     /// );
     /// ```
     #[cfg(feature = "unstable")]
-    fn enumerate_from<K>(self, start: K) -> EnumerateFrom<Self, K> where
-        Self: Sized,
+    fn enumerate_from<K>(self, start: K) -> EnumerateFrom<Self, K>
+        where Self: Sized
     {
         EnumerateFrom::new(self, start)
     }
@@ -636,8 +633,8 @@ pub trait Itertools : Iterator {
     /// assert_eq!(peekable.next(), Some(1));
     /// assert_eq!(peekable.peek(), Some(&2));
     /// ```
-    fn multipeek(self) -> MultiPeek<Self> where
-        Self: Sized
+    fn multipeek(self) -> MultiPeek<Self>
+        where Self: Sized
     {
         MultiPeek::new(self)
     }
@@ -667,9 +664,10 @@ pub trait Itertools : Iterator {
     ///         }),
     ///         vec![-6., 4., -1.]);
     /// ```
-    fn coalesce<F>(self, f: F) -> Coalesce<Self, F> where
-        Self: Sized,
-        F: FnMut(Self::Item, Self::Item) -> Result<Self::Item, (Self::Item, Self::Item)>
+    fn coalesce<F>(self, f: F) -> Coalesce<Self, F>
+        where Self: Sized,
+              F: FnMut(Self::Item, Self::Item)
+                       -> Result<Self::Item, (Self::Item, Self::Item)>
     {
         Coalesce::new(self, f)
     }
@@ -709,9 +707,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(data.into_iter().unique(),
     ///                         vec![10, 20, 30, 40, 50]);
     /// ```
-    fn unique(self) -> Unique<Self> where
-        Self: Sized,
-        Self::Item: Clone + Eq + Hash,
+    fn unique(self) -> Unique<Self>
+        where Self: Sized,
+              Self::Item: Clone + Eq + Hash
     {
         adaptors::unique(self)
     }
@@ -730,10 +728,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(data.into_iter().unique_by(|s| s.len()),
     ///                         vec!["a", "bb", "ccc"]);
     /// ```
-    fn unique_by<V, F>(self, f: F) -> UniqueBy<Self, V, F> where
-        Self: Sized,
-        V: Eq + Hash,
-        F: FnMut(&Self::Item) -> V
+    fn unique_by<V, F>(self, f: F) -> UniqueBy<Self, V, F>
+        where Self: Sized,
+              V: Eq + Hash,
+              F: FnMut(&Self::Item) -> V
     {
         UniqueBy::new(self, f)
     }
@@ -756,9 +754,9 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal(words, vec!["Warning:", "γ-radiation", "(ionizing)"]);
     /// ```
-    fn mend_slices(self) -> MendSlices<Self> where
-        Self: Sized,
-        Self::Item: misc::MendSlice
+    fn mend_slices(self) -> MendSlices<Self>
+        where Self: Sized,
+              Self::Item: misc::MendSlice
     {
         MendSlices::new(self)
     }
@@ -780,9 +778,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(hexadecimals.next(), Some('a'));
     ///
     /// ```
-    fn take_while_ref<'a, F>(&'a mut self, f: F) -> TakeWhileRef<'a, Self, F> where
-        Self: Clone,
-        F: FnMut(&Self::Item) -> bool,
+    fn take_while_ref<'a, F>(&'a mut self, f: F) -> TakeWhileRef<'a, Self, F>
+        where Self: Clone,
+              F: FnMut(&Self::Item) -> bool
     {
         TakeWhileRef::new(self, f)
     }
@@ -801,8 +799,8 @@ pub trait Itertools : Iterator {
     ///     "0123456789abcdef".chars());
     ///
     /// ```
-    fn while_some<A>(self) -> WhileSome<Self> where
-        Self: Sized + Iterator<Item=Option<A>>,
+    fn while_some<A>(self) -> WhileSome<Self>
+        where Self: Sized + Iterator<Item = Option<A>>
     {
         WhileSome::new(self)
     }
@@ -818,8 +816,9 @@ pub trait Itertools : Iterator {
     /// let it = (1..5).combinations();
     /// itertools::assert_equal(it, vec![(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]);
     /// ```
-    fn combinations(self) -> Combinations<Self> where
-        Self: Sized + Clone, Self::Item: Clone
+    fn combinations(self) -> Combinations<Self>
+        where Self: Sized + Clone,
+              Self::Item: Clone
     {
         Combinations::new(self)
     }
@@ -841,8 +840,9 @@ pub trait Itertools : Iterator {
     ///     vec![2, 3, 4],
     ///     ]);
     /// ```
-    fn combinations_n(self, n: usize) -> CombinationsN<Self> where
-        Self: Sized, Self::Item: Clone
+    fn combinations_n(self, n: usize) -> CombinationsN<Self>
+        where Self: Sized,
+              Self::Item: Clone
     {
         CombinationsN::new(self, n)
     }
@@ -864,9 +864,9 @@ pub trait Itertools : Iterator {
     /// let it = (0..5).pad_using(10, |i| 2*i).rev();
     /// itertools::assert_equal(it, vec![18, 16, 14, 12, 10, 4, 3, 2, 1, 0]);
     /// ```
-    fn pad_using<F>(self, min: usize, f: F) -> PadUsing<Self, F> where
-        Self: Sized,
-        F: FnMut(usize) -> Self::Item,
+    fn pad_using<F>(self, min: usize, f: F) -> PadUsing<Self, F>
+        where Self: Sized,
+              F: FnMut(usize) -> Self::Item
     {
         PadUsing::new(self, min, f)
     }
@@ -883,9 +883,9 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal(flattened, vec![1, 2, 3, 4, 5, 6]);
     /// ```
-    fn flatten(self) -> Flatten<Self> where
-        Self: Sized,
-        Self::Item: IntoIterator,
+    fn flatten(self) -> Flatten<Self>
+        where Self: Sized,
+              Self::Item: IntoIterator
     {
         Flatten::new(self)
     }
@@ -906,8 +906,8 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(iter, vec![Some(1), Some(0), None]);
     /// itertools::assert_equal(iter_copy, vec![Some(1), Some(0), None]);
     /// ```
-    fn map_fn<B>(self, f: fn(Self::Item) -> B) -> MapFn<Self, B> where
-        Self: Sized
+    fn map_fn<B>(self, f: fn(Self::Item) -> B) -> MapFn<Self, B>
+        where Self: Sized
     {
         self.map(f)
     }
@@ -924,13 +924,13 @@ pub trait Itertools : Iterator {
     /// let text = "Hα";
     /// assert_eq!(text.chars().find_position(|ch| ch.is_lowercase()), Some((1, 'α')));
     /// ```
-    fn find_position<P>(&mut self, mut pred: P) -> Option<(usize, Self::Item)> where
-        P: FnMut(&Self::Item) -> bool,
+    fn find_position<P>(&mut self, mut pred: P) -> Option<(usize, Self::Item)>
+        where P: FnMut(&Self::Item) -> bool
     {
         let mut index = 0usize;
         for elt in self {
             if pred(&elt) {
-                return Some((index, elt))
+                return Some((index, elt));
             }
             index += 1;
         }
@@ -948,14 +948,13 @@ pub trait Itertools : Iterator {
     /// iter.dropn(2);
     /// itertools::assert_equal(iter, "γ".chars());
     /// ```
-    fn dropn(&mut self, mut n: usize) -> usize
-    {
+    fn dropn(&mut self, mut n: usize) -> usize {
         // FIXME: Can we use .nth() somehow?
         let start = n;
         while n > 0 {
             match self.next() {
                 Some(..) => n -= 1,
-                None => break
+                None => break,
             }
         }
         start - n
@@ -973,8 +972,8 @@ pub trait Itertools : Iterator {
     /// let mut iter = "αβγ".chars().dropping(2);
     /// itertools::assert_equal(iter, "γ".chars());
     /// ```
-    fn dropping(mut self, n: usize) -> Self where
-        Self: Sized,
+    fn dropping(mut self, n: usize) -> Self
+        where Self: Sized
     {
         if n > 0 {
             self.nth(n - 1);
@@ -997,9 +996,9 @@ pub trait Itertools : Iterator {
     /// let init = vec![0, 3, 6, 9].into_iter().dropping_back(1);
     /// itertools::assert_equal(init, vec![0, 3, 6]);
     /// ```
-    fn dropping_back(mut self, n: usize) -> Self where
-        Self: Sized,
-        Self: DoubleEndedIterator,
+    fn dropping_back(mut self, n: usize) -> Self
+        where Self: Sized,
+              Self: DoubleEndedIterator
     {
         self.by_ref().rev().dropn(n);
         self
@@ -1022,16 +1021,18 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal(rx.iter(), vec![1, 3, 5, 7, 9]);
     /// ```
-    fn foreach<F>(&mut self, mut f: F) where
-        F: FnMut(Self::Item),
+    fn foreach<F>(&mut self, mut f: F)
+        where F: FnMut(Self::Item)
     {
-        for elt in self { f(elt) }
+        for elt in self {
+            f(elt)
+        }
     }
 
     /// `.collect_vec()` is simply a type specialization of `.collect()`,
     /// for convenience.
-    fn collect_vec(self) -> Vec<Self::Item> where
-        Self: Sized,
+    fn collect_vec(self) -> Vec<Self::Item>
+        where Self: Sized
     {
         self.collect()
     }
@@ -1052,15 +1053,15 @@ pub trait Itertools : Iterator {
     /// assert_eq!(xs, [1, 2, 3, 4]);
     /// ```
     #[inline]
-    fn set_from<'a, A: 'a, J>(&mut self, from: J) -> usize where
-        Self: Iterator<Item=&'a mut A>,
-        J: IntoIterator<Item=A>,
+    fn set_from<'a, A: 'a, J>(&mut self, from: J) -> usize
+        where Self: Iterator<Item = &'a mut A>,
+              J: IntoIterator<Item = A>
     {
         let mut count = 0;
         for elt in from {
             match self.next() {
                 None => break,
-                Some(ptr) => *ptr = elt
+                Some(ptr) => *ptr = elt,
             }
             count += 1;
         }
@@ -1077,8 +1078,8 @@ pub trait Itertools : Iterator {
     /// assert_eq!(["a", "b", "c"].iter().join(", "), "a, b, c");
     /// assert_eq!([1, 2, 3].iter().join(", "), "1, 2, 3");
     /// ```
-    fn join(&mut self, sep: &str) -> String where
-        Self::Item: std::fmt::Display,
+    fn join(&mut self, sep: &str) -> String
+        where Self::Item: std::fmt::Display
     {
         match self.next() {
             None => String::new(),
@@ -1173,9 +1174,9 @@ pub trait Itertools : Iterator {
     ///           .is_err()
     /// );
     /// ```
-    fn fold_results<A, E, B, F>(&mut self, mut start: B, mut f: F) -> Result<B, E> where
-        Self: Iterator<Item=Result<A, E>>,
-        F: FnMut(B, A) -> B,
+    fn fold_results<A, E, B, F>(&mut self, mut start: B, mut f: F) -> Result<B, E>
+        where Self: Iterator<Item = Result<A, E>>,
+              F: FnMut(B, A) -> B
     {
         for elt in self {
             match elt {
@@ -1205,9 +1206,9 @@ pub trait Itertools : Iterator {
     /// assert!(more_values.fold_options(0, Add::add).is_none());
     /// assert_eq!(more_values.next().unwrap(), Some(0));
     /// ```
-    fn fold_options<A, B, F>(&mut self, mut start: B, mut f: F) -> Option<B> where
-        Self: Iterator<Item=Option<A>>,
-        F: FnMut(B, A) -> B,
+    fn fold_options<A, B, F>(&mut self, mut start: B, mut f: F) -> Option<B>
+        where Self: Iterator<Item = Option<A>>,
+              F: FnMut(B, A) -> B
     {
         for elt in self {
             match elt {
@@ -1230,8 +1231,8 @@ pub trait Itertools : Iterator {
     /// assert_eq!((0..10).fold1(|x, y| x + y).unwrap_or(0), 45);
     /// assert_eq!((0..0).fold1(|x, y| x * y), None);
     /// ```
-    fn fold1<F>(&mut self, mut f: F) -> Option<Self::Item> where
-        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+    fn fold1<F>(&mut self, mut f: F) -> Option<Self::Item>
+        where F: FnMut(Self::Item, Self::Item) -> Self::Item
     {
         match self.next() {
             None => None,
@@ -1255,8 +1256,7 @@ pub trait Itertools : Iterator {
     /// assert_eq!([1, 2, 3].iter().is_empty_hint(), Some(false));
     /// assert_eq!((0..10).filter(|&x| x > 0).is_empty_hint(), None);
     /// ```
-    fn is_empty_hint(&self) -> Option<bool>
-    {
+    fn is_empty_hint(&self) -> Option<bool> {
         let (low, opt_hi) = self.size_hint();
         // check for erronous hint
         if let Some(hi) = opt_hi {
@@ -1344,10 +1344,10 @@ impl<T: ?Sized> Itertools for T where T: Iterator { }
 /// assert!(itertools::equal(vec![1, 2, 3], 1..4));
 /// assert!(!itertools::equal(&[0, 0], &[0, 0, 0]));
 /// ```
-pub fn equal<I, J>(a: I, b: J) -> bool where
-    I: IntoIterator,
-    J: IntoIterator,
-    I::Item: PartialEq<J::Item>,
+pub fn equal<I, J>(a: I, b: J) -> bool
+    where I: IntoIterator,
+          J: IntoIterator,
+          I::Item: PartialEq<J::Item>
 {
     let mut ia = a.into_iter();
     let mut ib = b.into_iter();
@@ -1414,10 +1414,10 @@ pub fn assert_equal<I, J>(a: I, b: J)
 /// assert_eq!(data, [7, 7, 7, 1, 1, 1, 1]);
 /// assert_eq!(split_index, 3);
 /// ```
-pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize where
-    I: IntoIterator<Item=&'a mut A>,
-    I::IntoIter: DoubleEndedIterator,
-    F: FnMut(&A) -> bool,
+pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
+    where I: IntoIterator<Item = &'a mut A>,
+          I::IntoIter: DoubleEndedIterator,
+          F: FnMut(&A) -> bool
 {
     let mut split_index = 0;
     let mut iter = iter.into_iter();
@@ -1437,4 +1437,3 @@ pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize where
     }
     split_index
 }
-

--- a/src/linspace.rs
+++ b/src/linspace.rs
@@ -54,7 +54,9 @@ impl<F> DoubleEndedIterator for Linspace<F>
     }
 }
 
-impl<F> ExactSizeIterator for Linspace<F> where Linspace<F>: Iterator { }
+impl<F> ExactSizeIterator for Linspace<F>
+    where Linspace<F>: Iterator
+{}
 
 /// Return an iterator of evenly spaced floats.
 ///
@@ -71,13 +73,13 @@ impl<F> ExactSizeIterator for Linspace<F> where Linspace<F>: Iterator { }
 ///                         vec![0., 0.25, 0.5, 0.75, 1.0]);
 /// ```
 #[inline]
-pub fn linspace<F>(a: F, b: F, n: usize) -> Linspace<F> where
-    F: Copy + Sub<Output=F> + Div<Output=F> + Mul<Output=F>,
-    usize: ToFloat<F>,
+pub fn linspace<F>(a: F, b: F, n: usize) -> Linspace<F>
+    where F: Copy + Sub<Output = F> + Div<Output = F> + Mul<Output = F>,
+          usize: ToFloat<F>
 {
     let step = if n > 1 {
         let nf: F = n.to_float();
-        (b - a)/(nf - 1.to_float())
+        (b - a) / (nf - 1.to_float())
     } else {
         0.to_float()
     };

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -64,24 +64,21 @@ pub struct FlatTuples<I> {
     iter: I,
 }
 
-impl<I> FlatTuples<I>
-{
+impl<I> FlatTuples<I> {
     /// Create a new `FlatTuples`.
     #[doc(hidden)]
-    pub fn new(iter: I) -> Self
-    {
-        FlatTuples{iter: iter}
+    pub fn new(iter: I) -> Self {
+        FlatTuples { iter: iter }
     }
 }
 
-impl<X, T, I> Iterator for FlatTuples<I> where
-    I: Iterator<Item=(T, X)>,
-    T: AppendTuple<X>,
+impl<X, T, I> Iterator for FlatTuples<I>
+    where I: Iterator<Item = (T, X)>,
+          T: AppendTuple<X>
 {
     type Item = T::Result;
     #[inline]
-    fn next(&mut self) -> Option<Self::Item>
-    {
+    fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(t, x)| t.append(x))
     }
 
@@ -90,13 +87,12 @@ impl<X, T, I> Iterator for FlatTuples<I> where
     }
 }
 
-impl<X, T, I> DoubleEndedIterator for FlatTuples<I> where
-    I: DoubleEndedIterator<Item=(T, X)>,
-    T: AppendTuple<X>,
+impl<X, T, I> DoubleEndedIterator for FlatTuples<I>
+    where I: DoubleEndedIterator<Item = (T, X)>,
+          T: AppendTuple<X>
 {
     #[inline]
-    fn next_back(&mut self) -> Option<Self::Item>
-    {
+    fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|(t, x)| t.append(x))
     }
 }
@@ -106,26 +102,38 @@ impl<X, T, I> DoubleEndedIterator for FlatTuples<I> where
 pub trait GenericRange {
     #[doc(hidden)]
     /// Start index (inclusive)
-    fn start(&self) -> Option<usize> { None }
+    fn start(&self) -> Option<usize> {
+        None
+    }
     #[doc(hidden)]
     /// End index (exclusive)
-    fn end(&self) -> Option<usize> { None }
+    fn end(&self) -> Option<usize> {
+        None
+    }
 }
 
 
 impl GenericRange for RangeFull {}
 
 impl GenericRange for RangeFrom<usize> {
-    fn start(&self) -> Option<usize> { Some(self.start) }
+    fn start(&self) -> Option<usize> {
+        Some(self.start)
+    }
 }
 
 impl GenericRange for RangeTo<usize> {
-    fn end(&self) -> Option<usize> { Some(self.end) }
+    fn end(&self) -> Option<usize> {
+        Some(self.end)
+    }
 }
 
 impl GenericRange for Range<usize> {
-    fn start(&self) -> Option<usize> { Some(self.start) }
-    fn end(&self) -> Option<usize> { Some(self.end) }
+    fn start(&self) -> Option<usize> {
+        Some(self.start)
+    }
+    fn end(&self) -> Option<usize> {
+        Some(self.end)
+    }
 }
 
 /// Helper trait to convert usize to floating point type.
@@ -137,12 +145,16 @@ pub trait ToFloat<F> : Copy {
 
 impl ToFloat<f32> for usize {
     #[inline(always)]
-    fn to_float(self) -> f32 { self as f32 }
+    fn to_float(self) -> f32 {
+        self as f32
+    }
 }
 
 impl ToFloat<f64> for usize {
     #[inline(always)]
-    fn to_float(self) -> f64 { self as f64 }
+    fn to_float(self) -> f64 {
+        self as f64
+    }
 }
 
 /// A trait for items that can *maybe* be joined together.
@@ -150,14 +162,13 @@ pub trait MendSlice
 {
     #[doc(hidden)]
     /// If the slices are contiguous, return them joined into one.
-    fn mend(Self, Self) -> Result<Self, (Self, Self)> where Self: Sized;
+    fn mend(Self, Self) -> Result<Self, (Self, Self)>
+        where Self: Sized;
 }
 
-impl<'a, T> MendSlice for &'a [T]
-{
+impl<'a, T> MendSlice for &'a [T] {
     #[inline]
-    fn mend(a: Self, b: Self) -> Result<Self, (Self, Self)>
-    {
+    fn mend(a: Self, b: Self) -> Result<Self, (Self, Self)> {
         unsafe {
             let a_end = a.as_ptr().offset(a.len() as isize);
             if a_end == b.as_ptr() {
@@ -169,11 +180,9 @@ impl<'a, T> MendSlice for &'a [T]
     }
 }
 
-impl<'a, T> MendSlice for &'a mut [T]
-{
+impl<'a, T> MendSlice for &'a mut [T] {
     #[inline]
-    fn mend(a: Self, b: Self) -> Result<Self, (Self, Self)>
-    {
+    fn mend(a: Self, b: Self) -> Result<Self, (Self, Self)> {
         unsafe {
             let a_end = a.as_ptr().offset(a.len() as isize);
             if a_end == b.as_ptr() {
@@ -185,14 +194,10 @@ impl<'a, T> MendSlice for &'a mut [T]
     }
 }
 
-impl<'a> MendSlice for &'a str
-{
+impl<'a> MendSlice for &'a str {
     #[inline]
-    fn mend(a: Self, b: Self) -> Result<Self, (Self, Self)>
-    {
-        unsafe {
-            mem::transmute(MendSlice::mend(a.as_bytes(), b.as_bytes()))
-        }
+    fn mend(a: Self, b: Self) -> Result<Self, (Self, Self)> {
+        unsafe { mem::transmute(MendSlice::mend(a.as_bytes(), b.as_bytes())) }
     }
 }
 

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -15,9 +15,9 @@ pub struct PadUsing<I, F> {
     filler: F,
 }
 
-impl<I, F> PadUsing<I, F> where
-    I: Iterator,
-    F: FnMut(usize) -> I::Item,
+impl<I, F> PadUsing<I, F>
+    where I: Iterator,
+          F: FnMut(usize) -> I::Item
 {
     /// Create a new **PadUsing** iterator.
     pub fn new(iter: I, min: usize, filler: F) -> PadUsing<I, F> {
@@ -30,9 +30,9 @@ impl<I, F> PadUsing<I, F> where
     }
 }
 
-impl<I, F> Iterator for PadUsing<I, F> where
-    I: Iterator,
-    F: FnMut(usize) -> I::Item,
+impl<I, F> Iterator for PadUsing<I, F>
+    where I: Iterator,
+          F: FnMut(usize) -> I::Item
 {
     type Item = I::Item;
 
@@ -61,9 +61,9 @@ impl<I, F> Iterator for PadUsing<I, F> where
     }
 }
 
-impl<I, F> DoubleEndedIterator for PadUsing<I, F> where
-    I: DoubleEndedIterator + ExactSizeIterator,
-    F: FnMut(usize) -> I::Item,
+impl<I, F> DoubleEndedIterator for PadUsing<I, F>
+    where I: DoubleEndedIterator + ExactSizeIterator,
+          F: FnMut(usize) -> I::Item
 {
     fn next_back(&mut self) -> Option<I::Item> {
         if self.min == 0 {
@@ -80,5 +80,5 @@ impl<I, F> DoubleEndedIterator for PadUsing<I, F> where
 
 impl<I, F> ExactSizeIterator for PadUsing<I, F>
     where I: Iterator,
-          F: FnMut(usize) -> I::Item,
-{ }
+          F: FnMut(usize) -> I::Item
+{}

--- a/src/rciter.rs
+++ b/src/rciter.rs
@@ -11,30 +11,26 @@ pub struct RcIter<I> {
     pub rciter: Rc<RefCell<I>>,
 }
 
-impl<I> RcIter<I>
-{
+impl<I> RcIter<I> {
     /// Create a new RcIter.
-    pub fn new(iter: I) -> RcIter<I>
-    {
-        RcIter{rciter: Rc::new(RefCell::new(iter))}
+    pub fn new(iter: I) -> RcIter<I> {
+        RcIter { rciter: Rc::new(RefCell::new(iter)) }
     }
 }
 
-impl<I> Clone for RcIter<I>
-{
+impl<I> Clone for RcIter<I> {
     #[inline]
     fn clone(&self) -> RcIter<I> {
-        RcIter{rciter: self.rciter.clone()}
+        RcIter { rciter: self.rciter.clone() }
     }
 }
 
-impl<A, I> Iterator for RcIter<I> where
-    I: Iterator<Item=A>,
+impl<A, I> Iterator for RcIter<I>
+    where I: Iterator<Item = A>
 {
     type Item = A;
     #[inline]
-    fn next(&mut self) -> Option<A>
-    {
+    fn next(&mut self) -> Option<A> {
         self.rciter.borrow_mut().next()
     }
 
@@ -48,24 +44,22 @@ impl<A, I> Iterator for RcIter<I> where
     }
 }
 
-impl<I> DoubleEndedIterator for RcIter<I> where
-    I: DoubleEndedIterator,
+impl<I> DoubleEndedIterator for RcIter<I>
+    where I: DoubleEndedIterator
 {
     #[inline]
-    fn next_back(&mut self) -> Option<I::Item>
-    {
+    fn next_back(&mut self) -> Option<I::Item> {
         self.rciter.borrow_mut().next_back()
     }
 }
 /// Return an iterator from `&RcIter<I>` (by simply cloning it).
-impl<'a, I> IntoIterator for &'a RcIter<I> where
-    I: Iterator,
+impl<'a, I> IntoIterator for &'a RcIter<I>
+    where I: Iterator
 {
     type Item = I::Item;
     type IntoIter = RcIter<I>;
 
-    fn into_iter(self) -> RcIter<I>
-    {
+    fn into_iter(self) -> RcIter<I> {
         self.clone()
     }
 }

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -1,31 +1,30 @@
 
 /// An iterator that repeats an element exactly *n* times.
-pub struct RepeatN<A>
-{
+pub struct RepeatN<A> {
     elt: Option<A>,
     n: usize,
 }
 
-impl<A> RepeatN<A>
-{
+impl<A> RepeatN<A> {
     /// Create a new **RepeatN** with **n** repetitions.
-    pub fn new(elt: A, n: usize) -> Self
-    {
+    pub fn new(elt: A, n: usize) -> Self {
         if n == 0 {
-            RepeatN{elt: None, n: n}
+            RepeatN { elt: None, n: n }
         } else {
-            RepeatN{elt: Some(elt), n: n}
+            RepeatN {
+                elt: Some(elt),
+                n: n,
+            }
         }
     }
 }
 
-impl<A> Iterator for RepeatN<A> where
-    A: Clone,
+impl<A> Iterator for RepeatN<A>
+    where A: Clone
 {
     type Item = A;
 
-    fn next(&mut self) -> Option<Self::Item>
-    {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.n > 1 {
             self.n -= 1;
             self.elt.as_ref().cloned()
@@ -35,23 +34,20 @@ impl<A> Iterator for RepeatN<A> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (self.n, Some(self.n))
     }
 }
 
-impl<A> DoubleEndedIterator for RepeatN<A> where
-    A: Clone,
+impl<A> DoubleEndedIterator for RepeatN<A>
+    where A: Clone
 {
     #[inline]
-    fn next_back(&mut self) -> Option<Self::Item>
-    {
+    fn next_back(&mut self) -> Option<Self::Item> {
         self.next()
     }
 }
 
-impl<A> ExactSizeIterator for RepeatN<A> where
-    A: Clone,
-{
-}
+impl<A> ExactSizeIterator for RepeatN<A>
+    where A: Clone
+{}

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -9,8 +9,7 @@ pub type SizeHint = (usize, Option<usize>);
 
 /// Add **SizeHint** correctly.
 #[inline]
-pub fn add(a: SizeHint, b: SizeHint) -> SizeHint
-{
+pub fn add(a: SizeHint, b: SizeHint) -> SizeHint {
     let min = a.0.checked_add(b.0).unwrap_or(usize::MAX);
     let max = match (a.1, b.1) {
         (Some(x), Some(y)) => x.checked_add(y),
@@ -22,8 +21,7 @@ pub fn add(a: SizeHint, b: SizeHint) -> SizeHint
 
 /// Add **x** correctly to a **SizeHint**.
 #[inline]
-pub fn add_scalar(sh: SizeHint, x: usize) -> SizeHint
-{
+pub fn add_scalar(sh: SizeHint, x: usize) -> SizeHint {
     let (mut low, mut hi) = sh;
     low = low.saturating_add(x);
     hi = hi.and_then(|elt| elt.checked_add(x));
@@ -32,8 +30,7 @@ pub fn add_scalar(sh: SizeHint, x: usize) -> SizeHint
 
 /// Sbb **x** correctly to a **SizeHint**.
 #[inline]
-pub fn sub_scalar(sh: SizeHint, x: usize) -> SizeHint
-{
+pub fn sub_scalar(sh: SizeHint, x: usize) -> SizeHint {
     let (mut low, mut hi) = sh;
     low = low.saturating_sub(x);
     hi = hi.map(|elt| elt.saturating_sub(x));
@@ -53,8 +50,7 @@ pub fn sub_scalar(sh: SizeHint, x: usize) -> SizeHint
 ///            (usize::MAX, None));
 /// ```
 #[inline]
-pub fn mul_scalar(sh: SizeHint, x: usize) -> SizeHint
-{
+pub fn mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
     let (mut low, mut hi) = sh;
     low = low.checked_mul(x).unwrap_or(usize::MAX);
     if x == 0 {
@@ -81,8 +77,7 @@ pub fn mul_scalar(sh: SizeHint, x: usize) -> SizeHint
 ///            (0, Some(0)));
 /// ```
 #[inline]
-pub fn mul(a: SizeHint, b: SizeHint) -> SizeHint
-{
+pub fn mul(a: SizeHint, b: SizeHint) -> SizeHint {
     let low = a.0.checked_mul(b.0).unwrap_or(usize::MAX);
     let hi = match (a.1, b.1) {
         (Some(x), Some(y)) => x.checked_mul(y),
@@ -94,16 +89,15 @@ pub fn mul(a: SizeHint, b: SizeHint) -> SizeHint
 
 /// Return the maximum
 #[inline]
-pub fn max(a: SizeHint, b: SizeHint) -> SizeHint
-{
+pub fn max(a: SizeHint, b: SizeHint) -> SizeHint {
     let (a_lower, a_upper) = a;
     let (b_lower, b_upper) = b;
 
     let lower = cmp::max(a_lower, b_lower);
 
     let upper = match (a_upper, b_upper) {
-        (Some(x), Some(y)) => Some(cmp::max(x,y)),
-        _ => None
+        (Some(x), Some(y)) => Some(cmp::max(x, y)),
+        _ => None,
     };
 
     (lower, upper)
@@ -111,14 +105,13 @@ pub fn max(a: SizeHint, b: SizeHint) -> SizeHint
 
 /// Return the minimum
 #[inline]
-pub fn min(a: SizeHint, b: SizeHint) -> SizeHint
-{
+pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
     let (a_lower, a_upper) = a;
     let (b_lower, b_upper) = b;
     let lower = cmp::min(a_lower, b_lower);
     let upper = match (a_upper, b_upper) {
         (Some(u1), Some(u2)) => Some(cmp::min(u1, u2)),
-        _ => a_upper.or(b_upper)
+        _ => a_upper.or(b_upper),
     };
     (lower, upper)
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -24,38 +24,37 @@ pub struct RepeatCall<F> {
     f: F,
 }
 
-impl<F> RepeatCall<F>
-{
+impl<F> RepeatCall<F> {
     /// Create a new `RepeatCall` from a closure.
-    pub fn new<A>(func: F) -> Self where
-        F: FnMut() -> A,
+    pub fn new<A>(func: F) -> Self
+        where F: FnMut() -> A
     {
         RepeatCall { f: func }
     }
 }
 
-impl<A, F> Iterator for RepeatCall<F> where
-    F: FnMut() -> A,
+impl<A, F> Iterator for RepeatCall<F>
+    where F: FnMut() -> A
 {
     type Item = A;
 
     #[inline]
-    fn next(&mut self) -> Option<A>
-    {
+    fn next(&mut self) -> Option<A> {
         Some((self.f)())
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (usize::max_value(), None)
     }
 }
 
-impl<A, F> DoubleEndedIterator for RepeatCall<F> where
-    F: FnMut() -> A,
+impl<A, F> DoubleEndedIterator for RepeatCall<F>
+    where F: FnMut() -> A
 {
     #[inline]
-    fn next_back(&mut self) -> Option<A> { self.next() }
+    fn next_back(&mut self) -> Option<A> {
+        self.next()
+    }
 }
 
 
@@ -110,7 +109,7 @@ impl<A, St, F> Unfold<St, F>
     pub fn new(initial_state: St, f: F) -> Unfold<St, F> {
         Unfold {
             f: f,
-            state: initial_state
+            state: initial_state,
         }
     }
 }
@@ -131,4 +130,3 @@ impl<A, St, F> Iterator for Unfold<St, F>
         (0, None)
     }
 }
-

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -48,8 +48,7 @@ pub struct StrideMut<'a, A: 'a> {
 unsafe impl<'a, A> Send for StrideMut<'a, A> where A: Send {}
 unsafe impl<'a, A> Sync for StrideMut<'a, A> where A: Sync {}
 
-impl<'a, A> Stride<'a, A>
-{
+impl<'a, A> Stride<'a, A> {
     /// Create a Stride iterator from a raw pointer.
     pub unsafe fn from_ptr_len(begin: *const A, nelem: usize, stride: isize) -> Stride<'a, A>
     {
@@ -78,8 +77,7 @@ impl<'a, A> StrideMut<'a, A>
     }
 }
 
-fn div_rem(x: usize, d: usize) -> (usize, usize)
-{
+fn div_rem(x: usize, d: usize) -> (usize, usize) {
     (x / d, x % d)
 }
 
@@ -262,21 +260,17 @@ macro_rules! stride_impl {
 stride_impl!{struct Stride -> &'a [A], as_ptr, *const A, &'a A}
 stride_impl!{struct StrideMut -> &'a mut [A], as_mut_ptr, *mut A, &'a mut A}
 
-impl<'a, A> Clone for Stride<'a, A>
-{
-    fn clone(&self) -> Stride<'a, A>
-    {
+impl<'a, A> Clone for Stride<'a, A> {
+    fn clone(&self) -> Stride<'a, A> {
         *self
     }
 }
 
-impl<'a, A> IndexMut<usize> for StrideMut<'a, A>
-{
+impl<'a, A> IndexMut<usize> for StrideMut<'a, A> {
     /// Return a mutable reference to the element at a given index.
     ///
     /// **Panics** if the index is out of bounds.
-    fn index_mut<'b>(&'b mut self, i: usize) -> &'b mut A
-    {
+    fn index_mut<'b>(&'b mut self, i: usize) -> &'b mut A {
         assert!(i < self.len());
         unsafe {
             let ptr = self.begin.offset(self.offset + self.stride * (i as isize));

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -5,8 +5,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 
 /// Common buffer object for the two tee halves
-struct TeeBuffer<A, I>
-{
+struct TeeBuffer<A, I> {
     backlog: VecDeque<A>,
     iter: I,
     /// The owner field indicates which id should read from the backlog
@@ -16,15 +15,15 @@ struct TeeBuffer<A, I>
 /// One half of an iterator pair where both return the same elements.
 ///
 /// See [*.tee()*](trait.Itertools.html#method.tee) for more information.
-pub struct Tee<I> where
-    I: Iterator
+pub struct Tee<I>
+    where I: Iterator
 {
     rcbuffer: Rc<RefCell<TeeBuffer<I::Item, I>>>,
     id: bool,
 }
 
-pub fn new<I>(iter: I) -> (Tee<I>, Tee<I>) where
-    I: Iterator
+pub fn new<I>(iter: I) -> (Tee<I>, Tee<I>)
+    where I: Iterator
 {
     let buffer = TeeBuffer{backlog: VecDeque::new(), iter: iter, owner: false};
     let t1 = Tee{rcbuffer: Rc::new(RefCell::new(buffer)), id: true};
@@ -32,13 +31,12 @@ pub fn new<I>(iter: I) -> (Tee<I>, Tee<I>) where
     (t1, t2)
 }
 
-impl<I> Iterator for Tee<I> where
-    I: Iterator,
-    I::Item: Clone,
+impl<I> Iterator for Tee<I>
+    where I: Iterator,
+          I::Item: Clone
 {
     type Item = I::Item;
-    fn next(&mut self) -> Option<I::Item>
-    {
+    fn next(&mut self) -> Option<I::Item> {
         // .borrow_mut may fail here -- but only if the user has tied some kind of weird
         // knot where the iterator refers back to itself.
         let mut buffer = self.rcbuffer.borrow_mut();
@@ -58,8 +56,7 @@ impl<I> Iterator for Tee<I> where
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let buffer = self.rcbuffer.borrow();
         let sh = buffer.iter.size_hint();
 
@@ -72,7 +69,7 @@ impl<I> Iterator for Tee<I> where
     }
 }
 
-impl<I> ExactSizeIterator for Tee<I> where
-    I: ExactSizeIterator,
-    I::Item: Clone,
-{ }
+impl<I> ExactSizeIterator for Tee<I>
+    where I: ExactSizeIterator,
+          I::Item: Clone
+{}

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -18,20 +18,22 @@ pub struct ZipLongest<T, U> {
     b: Fuse<U>,
 }
 
-impl<T, U> ZipLongest<T, U> where
-    T: Iterator,
-    U: Iterator,
+impl<T, U> ZipLongest<T, U>
+    where T: Iterator,
+          U: Iterator
 {
     /// Create a new `ZipLongest` iterator.
-    pub fn new(a: T, b: U) -> ZipLongest<T, U>
-    {
-        ZipLongest{a: a.fuse(), b: b.fuse()}
+    pub fn new(a: T, b: U) -> ZipLongest<T, U> {
+        ZipLongest {
+            a: a.fuse(),
+            b: b.fuse(),
+        }
     }
 }
 
-impl<T, U> Iterator for ZipLongest<T, U> where
-    T: Iterator,
-    U: Iterator,
+impl<T, U> Iterator for ZipLongest<T, U>
+    where T: Iterator,
+          U: Iterator
 {
     type Item = EitherOrBoth<T::Item, U::Item>;
 
@@ -51,9 +53,9 @@ impl<T, U> Iterator for ZipLongest<T, U> where
     }
 }
 
-impl<T, U> DoubleEndedIterator for ZipLongest<T, U> where
-    T: DoubleEndedIterator + ExactSizeIterator,
-    U: DoubleEndedIterator + ExactSizeIterator,
+impl<T, U> DoubleEndedIterator for ZipLongest<T, U>
+    where T: DoubleEndedIterator + ExactSizeIterator,
+          U: DoubleEndedIterator + ExactSizeIterator
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -71,9 +73,9 @@ impl<T, U> DoubleEndedIterator for ZipLongest<T, U> where
     }
 }
 
-impl<T, U> ExactSizeIterator for ZipLongest<T, U> where
-    T: ExactSizeIterator,
-    U: ExactSizeIterator,
+impl<T, U> ExactSizeIterator for ZipLongest<T, U>
+    where T: ExactSizeIterator,
+          U: ExactSizeIterator
 {}
 
 

--- a/src/zipslices.rs
+++ b/src/zipslices.rs
@@ -44,7 +44,8 @@ impl<'a, 'b, A, B> ZipSlices<&'a [A], &'b [B]> {
 }
 
 impl<T, U> ZipSlices<T, U>
-    where T: Slice, U: Slice
+    where T: Slice,
+          U: Slice
 {
     /// Create a new `ZipSlices` from slices `a` and `b`.
     ///
@@ -64,7 +65,8 @@ impl<T, U> ZipSlices<T, U>
 }
 
 impl<T, U> Iterator for ZipSlices<T, U>
-    where T: Slice, U: Slice
+    where T: Slice,
+          U: Slice
 {
     type Item = (T::Item, U::Item);
 
@@ -91,7 +93,8 @@ impl<T, U> Iterator for ZipSlices<T, U>
 }
 
 impl<T, U> DoubleEndedIterator for ZipSlices<T, U>
-    where T: Slice, U: Slice
+    where T: Slice,
+          U: Slice
 {
     #[inline(always)]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -109,14 +112,20 @@ impl<T, U> DoubleEndedIterator for ZipSlices<T, U>
     }
 }
 
-impl<T, U> ExactSizeIterator for ZipSlices<T, U> where T: Slice, U: Slice { }
+impl<T, U> ExactSizeIterator for ZipSlices<T, U>
+    where T: Slice,
+          U: Slice
+{}
 
 unsafe impl<T, U> Slice for ZipSlices<T, U>
-    where T: Slice, U: Slice
+    where T: Slice,
+          U: Slice
 {
     type Item = (T::Item, U::Item);
 
-    fn len(&self) -> usize { self.len - self.index }
+    fn len(&self) -> usize {
+        self.len - self.index
+    }
 
     unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item {
         (self.t.get_unchecked(i),

--- a/src/ziptrusted.rs
+++ b/src/ziptrusted.rs
@@ -12,23 +12,23 @@ pub unsafe trait TrustedIterator : ExactSizeIterator
     /* no methods */
 }
 
-unsafe impl TrustedIterator for ::std::ops::Range<usize> { }
-unsafe impl TrustedIterator for ::std::ops::Range<u32> { }
-unsafe impl TrustedIterator for ::std::ops::Range<i32> { }
-unsafe impl TrustedIterator for ::std::ops::Range<u16> { }
-unsafe impl TrustedIterator for ::std::ops::Range<i16> { }
-unsafe impl TrustedIterator for ::std::ops::Range<u8> { }
-unsafe impl TrustedIterator for ::std::ops::Range<i8> { }
-unsafe impl<'a, T> TrustedIterator for slice::Iter<'a, T> { }
-unsafe impl<'a, T> TrustedIterator for slice::IterMut<'a, T> { }
-unsafe impl<T> TrustedIterator for vec::IntoIter<T> { }
+unsafe impl TrustedIterator for ::std::ops::Range<usize> {}
+unsafe impl TrustedIterator for ::std::ops::Range<u32> {}
+unsafe impl TrustedIterator for ::std::ops::Range<i32> {}
+unsafe impl TrustedIterator for ::std::ops::Range<u16> {}
+unsafe impl TrustedIterator for ::std::ops::Range<i16> {}
+unsafe impl TrustedIterator for ::std::ops::Range<u8> {}
+unsafe impl TrustedIterator for ::std::ops::Range<i8> {}
+unsafe impl<'a, T> TrustedIterator for slice::Iter<'a, T> {}
+unsafe impl<'a, T> TrustedIterator for slice::IterMut<'a, T> {}
+unsafe impl<T> TrustedIterator for vec::IntoIter<T> {}
 
-unsafe impl<I> TrustedIterator for iter::Rev<I> where
-    I: DoubleEndedIterator + TrustedIterator,
-{ }
-unsafe impl<I> TrustedIterator for iter::Take<I> where
-    I: TrustedIterator,
-{ }
+unsafe impl<I> TrustedIterator for iter::Rev<I>
+    where I: DoubleEndedIterator + TrustedIterator
+{}
+unsafe impl<I> TrustedIterator for iter::Take<I>
+    where I: TrustedIterator
+{}
 
 
 #[derive(Clone)]
@@ -59,23 +59,20 @@ unsafe impl<I> TrustedIterator for iter::Take<I> where
 /// ```
 pub struct ZipTrusted<T> {
     length: usize,
-    t: T
+    t: T,
 }
 
 pub trait SetLength {
     fn set_length(&mut self);
 }
 
-impl<T> ZipTrusted<T> where ZipTrusted<T>: SetLength
+impl<T> ZipTrusted<T>
+    where ZipTrusted<T>: SetLength
 {
     /// Create a new **ZipTrusted** from a tuple of iterators.
     #[inline]
-    pub fn new(t: T) -> ZipTrusted<T>
-    {
-        let mut iter = ZipTrusted {
-            length: 0,
-            t: t,
-        };
+    pub fn new(t: T) -> ZipTrusted<T> {
+        let mut iter = ZipTrusted { length: 0, t: t };
         iter.set_length();
         iter
     }
@@ -163,4 +160,3 @@ impl_zip_trusted!(A, B, C, D, E, F);
 impl_zip_trusted!(A, B, C, D, E, F, G);
 impl_zip_trusted!(A, B, C, D, E, F, G, H);
 impl_zip_trusted!(A, B, C, D, E, F, G, H, I);
-

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -25,17 +25,16 @@ use super::size_hint;
 /// assert_eq!(xs, [69, 106, 103]);
 /// ```
 pub struct Zip<T> {
-    t: T
+    t: T,
 }
 
-impl<T> Zip<T> where
-    T: IntoIteratorTuple,
-    Zip<T::Output>: Iterator
+impl<T> Zip<T>
+    where T: IntoIteratorTuple,
+          Zip<T::Output>: Iterator
 {
     /// Create a new `Zip` from a tuple of iterators.
-    pub fn new(t: T) -> Zip<T::Output>
-    {
-        Zip{t: t.into_iterator_tuple()}
+    pub fn new(t: T) -> Zip<T::Output> {
+        Zip { t: t.into_iterator_tuple() }
     }
 }
 
@@ -107,4 +106,3 @@ impl_zip_iter!(A, B, C, D, E, F);
 impl_zip_iter!(A, B, C, D, E, F, G);
 impl_zip_iter!(A, B, C, D, E, F, G, H);
 impl_zip_iter!(A, B, C, D, E, F, G, H, I);
-


### PR DESCRIPTION
Format using rustfmt, but manually choose changes. This fixes brace and
where style project wide, while skipping most of the expression
formatting.

config:

```
verbose = true
ideal_width = 80
max_width = 85
fn_call_width = 80
fn_return_indent = "WithWhereClause"
fn_args_density = "Compressed"
normalise_comments = false
where_density = "Tall"
```