### PR TITLE
Add fold_while (fold with short-circuit).

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -28,6 +28,13 @@ macro_rules! clone_fields {
     );
 }
 
+/// An enum used for controlling the execution of `.fold_while()`.
+/// 
+/// See [*`.fold_while()`*](trait.Itertools.html#method.fold_while) for more information.
+pub enum FoldWhile<T> {
+    Continue(T),
+    Done(T),
+}
 
 /// An iterator adaptor that alternates elements from two iterators until both
 /// run out.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub use adaptors::{
     Unique,
     UniqueBy,
     Flatten,
+    FoldWhile,
 };
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
@@ -1245,6 +1246,64 @@ pub trait Itertools : Iterator {
                 Some(x)
             }
         }
+    }
+
+    /// An iterator adaptor that applies a function, producing a single, final value.
+    ///
+    /// `fold_while()` is basically equivalent to `fold()` but with additional support for
+    /// early exit via short-circuiting.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    /// use itertools::FoldWhile::{Continue, Done};
+    ///
+    /// let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    ///
+    /// let mut result = 0;
+    ///
+    /// // for loop:
+    /// for i in &numbers {
+    ///     if *i > 5 {
+    ///         break;
+    ///     }
+    ///     result = result + i;
+    /// }
+    ///
+    /// // fold:
+    /// let result2 = numbers.iter().fold(0, |acc, x| {
+    ///     if *x > 5 { acc } else { acc + x }
+    /// });
+    ///
+    /// // fold_while:
+    /// let result3 = numbers.iter().fold_while(0, |acc, x| {
+    ///     if *x > 5 { Done(acc) } else { Continue(acc + x) }
+    /// });
+    ///
+    /// // they're the same
+    /// assert_eq!(result, result2);
+    /// assert_eq!(result2, result3);
+    /// ```
+    ///
+    /// The big difference between the computations of `result2` and `result3` is that while
+    /// `fold()` called the provided closure for every item of the callee iterator,
+    /// `fold_while()` actually stopped iterating as soon as it encountered `Fold::Done(_)`.
+    fn fold_while<B, F>(self, init: B, mut f: F) -> B
+        where Self: Sized,
+              F: FnMut(B, Self::Item) -> FoldWhile<B>
+    {
+        let mut accum = init;
+        for item in self {
+            match f(accum, item) {
+                FoldWhile::Continue(res) => {
+                    accum = res;
+                }
+                FoldWhile::Done(res) => {
+                    accum = res;
+                    break;
+                }
+            }
+        }
+        accum
     }
 
     /// Tell if the iterator is empty or not according to its size hint.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ extern crate permutohedron;
 use it::Itertools;
 use it::Interleave;
 use it::Zip;
+use it::FoldWhile;
 
 #[test]
 fn product2() {
@@ -179,7 +180,7 @@ fn intersperse() {
 fn linspace() {
     let iter = it::linspace::<f32>(0., 2., 3);
     it::assert_equal(iter, vec![0., 1., 2.]);
-    
+
     let iter = it::linspace::<f32>(0., 1.0, 11);
     for (a, b) in iter.zip(vec![ 0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]) {
         assert!((a - b).abs() < 1.0e-6);
@@ -254,7 +255,7 @@ fn group_by() {
     let xs = [0, 1, 1, 1, 2, 1, 3, 3];
     let ans = vec![(0, vec![0]), (1, vec![1, 1, 1]),
                    (2, vec![2]), (1, vec![1]), (3, vec![3, 3])];
-    
+
     let gb = xs.iter().cloned().group_by(|elt| *elt);
     it::assert_equal(gb, ans.into_iter());
 }
@@ -915,4 +916,21 @@ fn diff_shorter() {
         Some(it::Diff::Shorter(len, _)) => len == 2,
         _ => false,
     });
+}
+
+#[test]
+fn fold_while() {
+    let mut iterations = 0;
+    let vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let sum = vec.into_iter().fold_while(0, |acc, item| {
+        iterations += 1;
+        let new_sum = acc.clone() + item;
+        if new_sum <= 20 {
+            FoldWhile::Continue(new_sum)
+        } else {
+            FoldWhile::Done(acc)
+        }
+    });
+    assert_eq!(iterations, 6);
+    assert_eq!(sum, 15);
 }


### PR DESCRIPTION
I've been in need for a pure loop with short circuiting and return value.
So I wrote a μ-crate `fold_while` which enables just that.

And before cluttering crates.io with yet another one-trick-pony I figured I'd first try to get it added to the mother of all iter crates.

`fold_while` turns this:

```rust
let mut result = 0;
for i in (0..10) {
    if i > 5 { break; }
    result = result + i;
}
```

into this:

```rust
use itertools::Itertools;
use itertools::FoldWhile::{Continue, Exit};

let result = (0..10).fold_while(0, |acc, i| {
    if i > 5 { Exit(acc) } else { Continue(acc + i) }
});
```

I'd love to get this added to itertools.