### PR TITLE
Add minmax() and minmax_by_key() adapters (#79)

### DIFF
--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -1,0 +1,44 @@
+/// `MinMaxResult` is an enum returned by `minmax`. See `Itertools::minmax()` for
+/// more detail.
+#[derive(PartialEq, Debug)]
+pub enum MinMaxResult<T> {
+    /// Empty iterator
+    NoElements,
+
+    /// Iterator with one element, so the minimum and maximum are the same
+    OneElement(T),
+
+    /// More than one element in the iterator, the first element is not larger
+    /// than the second
+    MinMax(T, T)
+}
+
+impl<T: Clone> MinMaxResult<T> {
+    /// `into_option` creates an `Option` of type `(T, T)`. The returned `Option`
+    /// has variant `None` if and only if the `MinMaxResult` has variant
+    /// `NoElements`. Otherwise variant `Some(x, y)` is returned where `x <= y`.
+    /// If `MinMaxResult` has variant `OneElement(x)`, performing this operation
+    /// will make one clone of `x`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use itertools::MinMaxResult::{self, NoElements, OneElement, MinMax};
+    ///
+    /// let r: MinMaxResult<i32> = NoElements;
+    /// assert_eq!(r.into_option(), None);
+    ///
+    /// let r = OneElement(1);
+    /// assert_eq!(r.into_option(), Some((1, 1)));
+    ///
+    /// let r = MinMax(1, 2);
+    /// assert_eq!(r.into_option(), Some((1, 2)));
+    /// ```
+    pub fn into_option(self) -> Option<(T,T)> {
+        match self {
+            MinMaxResult::NoElements => None,
+            MinMaxResult::OneElement(x) => Some((x.clone(), x)),
+            MinMaxResult::MinMax(x, y) => Some((x, y))
+        }
+    }
+}

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -1,3 +1,5 @@
+use Itertools;
+
 /// `MinMaxResult` is an enum returned by `minmax`. See `Itertools::minmax()` for
 /// more detail.
 #[derive(PartialEq, Debug)]
@@ -41,4 +43,73 @@ impl<T: Clone> MinMaxResult<T> {
             MinMaxResult::MinMax(x, y) => Some((x, y))
         }
     }
+}
+
+/// Implementation guts for `minmax` and `minmax_by_key`.
+pub fn minmax_impl<I: Itertools, K, F, L, G>(mut it: I, mut key_for: F,
+                                             lt: L, gt: G) -> MinMaxResult<I::Item>
+    where I: Sized, F: FnMut(&I::Item) -> K,
+          L: Fn(&I::Item, &I::Item, &K, &K) -> bool,
+          G: Fn(&I::Item, &I::Item, &K, &K) -> bool
+{
+    let (mut min, mut max, mut min_key, mut max_key) = match it.next() {
+        None => return MinMaxResult::NoElements,
+        Some(x) => {
+            match it.next() {
+                None => return MinMaxResult::OneElement(x),
+                Some(y) => {
+                    let xk = key_for(&x);
+                    let yk = key_for(&y);
+                    if !gt(&x, &y, &xk, &yk) {(x, y, xk, yk)} else {(y, x, yk, xk)}
+                }
+            }
+        }
+    };
+
+    loop {
+        // `first` and `second` are the two next elements we want to look
+        // at.  We first compare `first` and `second` (#1). The smaller one
+        // is then compared to current minimum (#2). The larger one is
+        // compared to current maximum (#3). This way we do 3 comparisons
+        // for 2 elements.
+        let first = match it.next() {
+            None => break,
+            Some(x) => x
+        };
+        let second = match it.next() {
+            None => {
+                let first_key = key_for(&first);
+                if lt(&first, &min, &first_key, &min_key) {
+                    min = first;
+                } else if !lt(&first, &max, &first_key, &max_key) {
+                    max = first;
+                }
+                break;
+            }
+            Some(x) => x
+        };
+        let first_key = key_for(&first);
+        let second_key = key_for(&second);
+        if !gt(&first, &second, &first_key, &second_key) {
+            if lt(&first, &min, &first_key, &min_key) {
+                min = first;
+                min_key = first_key;
+            }
+            if !lt(&second, &max, &second_key, &max_key) {
+                max = second;
+                max_key = second_key;
+            }
+        } else {
+            if lt(&second, &min, &second_key, &min_key) {
+                min = second;
+                min_key = second_key;
+            }
+            if !lt(&first, &max, &first_key, &max_key) {
+                max = first;
+                max_key = first_key;
+            }
+        }
+    }
+
+    MinMaxResult::MinMax(min, max)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -934,3 +934,39 @@ fn fold_while() {
     assert_eq!(iterations, 6);
     assert_eq!(sum, 15);
 }
+
+#[test]
+fn minmax() {
+    use std::cmp::Ordering;
+    use it::MinMaxResult;
+
+    // A peculiar type: Equality compares both tuple items, but ordering only the
+    // first item.  This is so we can check the stability property easily.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct Val(u32, u32);
+
+    impl PartialOrd<Val> for Val {
+        fn partial_cmp(&self, other: &Val) -> Option<Ordering> {
+            self.0.partial_cmp(&other.0)
+        }
+    }
+
+    impl Ord for Val {
+        fn cmp(&self, other: &Val) -> Ordering {
+            self.0.cmp(&other.0)
+        }
+    }
+
+    assert_eq!(None::<Option<u32>>.iter().minmax(), MinMaxResult::NoElements);
+
+    assert_eq!(Some(1u32).iter().minmax(), MinMaxResult::OneElement(&1));
+
+    let data = vec![Val(0, 1), Val(2, 0), Val(0, 2), Val(1, 0), Val(2, 1)];
+
+    let minmax = data.iter().minmax();
+    assert_eq!(minmax, MinMaxResult::MinMax(&Val(0, 1), &Val(2, 1)));
+
+    let (min, max) = data.iter().minmax_by_key(|v| v.1).into_option().unwrap();
+    assert_eq!(min, &Val(2, 0));
+    assert_eq!(max, &Val(0, 2));
+}


### PR DESCRIPTION
This time, stolen + adapted the old stdlib code.

I had to duplicate most of the code; the `minmax -> minmax_by_key(|x| x)` definition produced lifetime errors that I didn't find a fix for. Is there one?