### PR TITLE
Add .format_default()

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -50,17 +50,17 @@ impl<'a, I, F> fmt::Display for Format<'a, I, F>
     where I: Iterator,
           F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut cb = &mut |disp: &fmt::Display| write!(fmt, "{}", disp);
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (ref mut iter, ref mut format) = *self.inner.borrow_mut();
 
         if let Some(fst) = iter.next() {
-            try!(format(fst, cb));
+            try!(format(fst, &mut |disp: &fmt::Display| disp.fmt(f)));
             for elt in iter {
                 if self.sep.len() > 0 {
-                    try!(cb(&self.sep));
+
+                    try!(f.write_str(self.sep));
                 }
-                try!(format(elt, cb));
+                try!(format(elt, &mut |disp: &fmt::Display| disp.fmt(f)));
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub use adaptors::{
 #[cfg(feature = "unstable")]
 pub use adaptors::EnumerateFrom;
 pub use diff::{diff_with, Diff};
-pub use format::Format;
+pub use format::{Format, FormatDefault};
 pub use free::{enumerate, rev};
 pub use groupbylazy::{ChunksLazy, Chunk, Chunks, GroupByLazy, Group, Groups};
 pub use intersperse::Intersperse;
@@ -1117,6 +1117,28 @@ pub trait Itertools : Iterator {
     }
 
     /// Format all iterator elements, separated by `sep`.
+    ///
+    /// All elements are formatted (both Display or Debug supported)
+    /// with `sep` inserted between each element.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let data = [0, 7, 2, 3];
+    /// assert_eq!(
+    ///     format!("{}", data.iter().format_default(", ")),
+    ///     "0, 7, 2, 3"
+    /// );
+    /// ```
+    fn format_default(self, sep: &str) -> FormatDefault<Self>
+        where Self: Sized,
+    {
+        format::new_format_default(self, sep)
+    }
+
+    /// Format all iterator elements, separated by `sep`.
+    ///
+    /// This is a customizable version of `.format_default()`.
     ///
     /// The supplied closure `format` is called once per iterator element,
     /// with two arguments: the element and a callback that takes a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1118,17 +1118,16 @@ pub trait Itertools : Iterator {
 
     /// Format all iterator elements, separated by `sep`.
     ///
-    /// All elements are formatted (both Display or Debug supported)
+    /// All elements are formatted (any formatting trait)
     /// with `sep` inserted between each element.
     ///
     /// ```
     /// use itertools::Itertools;
     ///
-    /// let data = [0, 7, 2, 3];
+    /// let data = [1.1, 2.71828, -3.];
     /// assert_eq!(
-    ///     format!("{}", data.iter().format_default(", ")),
-    ///     "0, 7, 2, 3"
-    /// );
+    ///     format!("{:.2}", data.iter().format_default(", ")),
+    ///            "1.10, 2.72, -3.00");
     /// ```
     fn format_default(self, sep: &str) -> FormatDefault<Self>
         where Self: Sized,
@@ -1151,7 +1150,7 @@ pub trait Itertools : Iterator {
     /// use itertools::Itertools;
     ///
     /// let data = [1.1, 2.71828, -3.];
-    /// let data_formatter = data.iter().format(", ", |elt, f| f(&format_args!("{:2.2}", elt)));
+    /// let data_formatter = data.iter().format(", ", |elt, f| f(&format_args!("{:.2}", elt)));
     /// assert_eq!(format!("{}", data_formatter),
     ///            "1.10, 2.72, -3.00");
     ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -981,4 +981,8 @@ fn format() {
     assert_eq!(t1, ans1);
     let t2 = format!("{:?}", data.iter().format_default("--"));
     assert_eq!(t2, ans2);
+
+    let dataf = [1.1, 2.71828, -22.];
+    let t3 = format!("{:.2e}", dataf.iter().format_default(", "));
+    assert_eq!(t3, "1.10e0, 2.72e0, -2.20e1");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -970,3 +970,15 @@ fn minmax() {
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
 }
+
+#[test]
+fn format() {
+    let data = [0, 1, 2, 3];
+    let ans1 = "0, 1, 2, 3";
+    let ans2 = "0--1--2--3";
+
+    let t1 = format!("{}", data.iter().format_default(", "));
+    assert_eq!(t1, ans1);
+    let t2 = format!("{:?}", data.iter().format_default("--"));
+    assert_eq!(t2, ans2);
+}


### PR DESCRIPTION
A simpler and easier to use version of .format()

This was suggested by [leonardo on the forum. ](https://users.rust-lang.org/t/enumerate-a-vector-of-results/5237/13?u=bluss) We don't want to rename format, but try to pick a good name for this anyway. This version is simpler and it can support all formatting traits.