### PR TITLE
avoid calculating b

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 Cargo.lock
+.project 
+src/main.rs

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -331,8 +331,7 @@ impl<I, J> Iterator for Product<I, J>
 {
     type Item = (I::Item, J::Item);
     fn next(&mut self) -> Option<(I::Item, J::Item)> {
-		fn get_next_b() { 
-			match self.b.next() {
+		let get_next_b = || match self.b.next() {
 				None => {
 					self.b = self.b_orig.clone();
 					match self.b.next() {
@@ -344,8 +343,7 @@ impl<I, J> Iterator for Product<I, J>
 					}
 				}
 				Some(x) => x
-			}
-        }
+			};
         match self.a_cur {
             None => None,
             Some(ref a) => {

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -331,23 +331,25 @@ impl<I, J> Iterator for Product<I, J>
 {
     type Item = (I::Item, J::Item);
     fn next(&mut self) -> Option<(I::Item, J::Item)> {
-        let elt_b = match self.b.next() {
-            None => {
-                self.b = self.b_orig.clone();
-                match self.b.next() {
-                    None => return None,
-                    Some(x) => {
-                        self.a_cur = self.a.next();
-                        x
-                    }
-                }
-            }
-            Some(x) => x
-        };
+		fn get_next_b() { 
+			match self.b.next() {
+				None => {
+					self.b = self.b_orig.clone();
+					match self.b.next() {
+						None => return None,
+						Some(x) => {
+							self.a_cur = self.a.next();
+							x
+						}
+					}
+				}
+				Some(x) => x
+			}
+        }
         match self.a_cur {
             None => None,
             Some(ref a) => {
-                Some((a.clone(), elt_b))
+                Some((a.clone(), get_next_b()))
             }
         }
     }


### PR DESCRIPTION
I figure this is more efficient, to return as early as possible, since when `a_cur` is None, it's not necessary to get the next item of b.  