### PR TITLE
Add `exhaust` which simply exhausts the iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1535,7 +1535,7 @@ pub trait Itertools : Iterator {
     fn exhaust(self)
         where Self: Sized,
     {
-        self.count();
+        for _ in self { }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1530,6 +1530,13 @@ pub trait Itertools : Iterator {
             |x, y, _, _| Ordering::Less == compare(x, y)
         )
     }
+
+    /// Exhaust the iterator by repeatedly calling `next()`.
+    fn exhaust(self)
+        where Self: Sized,
+    {
+        self.count();
+    }
 }
 
 impl<T: ?Sized> Itertools for T where T: Iterator { }


### PR DESCRIPTION
This is useful for iterators which are simply used for their side
effects.

The new function is added to make intent clearer for places where you'd
previously call `count` or similar to exhaust the iterator.
