### PR TITLE
Fix bug in kmerge (heapify)

### DIFF
--- a/src/kmerge.rs
+++ b/src/kmerge.rs
@@ -119,7 +119,7 @@ impl<I> Ord for HeadTail<I>
 
 /// Make `data` a heap (max-heap w.r.t T's Ord).
 fn heapify<T: Ord>(data: &mut [T]) {
-    for i in 0..data.len() / 2 {
+    for i in (0..data.len() / 2).rev() {
         sift_down(data, i);
     }
 }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -283,6 +283,18 @@ quickcheck! {
         merged.sort();
         itertools::equal(merged.into_iter(), kmerge(vec![sa, sb, sc]))
     }
+
+    // Any number of input iterators
+    fn equal_kmerge_2(mut inputs: Vec<Vec<i16>>) -> bool {
+        use itertools::free::kmerge;
+        // sort the inputs
+        for input in &mut inputs {
+            input.sort();
+        }
+        let mut merged = inputs.concat();
+        merged.sort();
+        itertools::equal(merged.into_iter(), kmerge(inputs))
+    }
     fn size_kmerge(a: Iter<i16>, b: Iter<i16>, c: Iter<i16>) -> bool {
         use itertools::free::kmerge;
         correct_size_hint(kmerge(vec![a, b, c]))

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -411,6 +411,13 @@ fn kmerge() {
 }
 
 #[test]
+fn kmerge_2() {
+    let its = vec![3, 2, 1, 0].into_iter().map(|s| (s..10).step(4));
+    
+    it::assert_equal(its.kmerge(), (0..10));
+}
+
+#[test]
 fn kmerge_empty() {
     let its = (0..4).map(|_| (0..0));
     assert_eq!(its.kmerge().next(), None);


### PR DESCRIPTION
Our venture with bespoke heap code didn't go so well after all. Fix
a bug in heapify.

Also extended the quickcheck to test kmerge more extensively.

Thanks to @tailhook for the test case

Fixes #134