### PR TITLE
Implemented minmax_by

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1530,6 +1530,25 @@ pub trait Itertools : Iterator {
     {
         minmax::minmax_impl(self, f, |_, _, xk, yk| xk < yk, |_, _, xk, yk| xk > yk)
     }
+
+    /// Return the minimum and maximum element of an iterator, as determined by
+    /// the specified comparison function.
+    ///
+    /// The return value is a variant of `MinMaxResult` like for `minmax()`.
+    ///
+    /// For the minimum, the first minimal element is returned.  For the maximum,
+    /// the last maximal element wins.  This matches the behavior of the standard
+    /// `Iterator::min()` and `Iterator::max()` methods.
+    fn minmax_by<F>(self, compare: F) -> MinMaxResult<Self::Item>
+        where Self: Sized, F: Fn(&Self::Item, &Self::Item) -> Ordering
+    {
+        minmax::minmax_impl(
+            self,
+            |_| (),
+            |x, y, _, _| Ordering::Less == compare(x, y),
+            |x, y, _, _| Ordering::Greater == compare(x, y)
+        )
+    }
 }
 
 impl<T: ?Sized> Itertools for T where T: Iterator { }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -976,6 +976,10 @@ fn minmax() {
     let (min, max) = data.iter().minmax_by_key(|v| v.1).into_option().unwrap();
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
+
+    let (min, max) = data.iter().minmax_by(|x, y| x.1.cmp(&y.1)).into_option().unwrap();
+    assert_eq!(min, &Val(2, 0));
+    assert_eq!(max, &Val(0, 2));
 }
 
 #[test]


### PR DESCRIPTION
I implemented a basic version of `minmax_by` (similar to `sort_by`).

Note that it is (at least, currently) implemented to take an `Fn` (instead of an `FnMut`) as a comparison function. Do you think a `FnMut` comparison function would offer sensible advantages?

Just in case this matters: I also suggested to add `max_by` and `min_by` to the stdlib, so `minmax_by` would be in line with that (https://github.com/rust-lang/rust/pull/35856).