### PR TITLE
Initial .starmap() implementation (WIP)

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -1448,3 +1448,57 @@ impl<I> Clone for Flatten<I> where
         }
     }
 }
+
+pub struct Starmap<I, F, A>
+    where I: Iterator<Item=A>,
+{
+    iter: I,
+    f: F,
+}
+
+impl<I, F, A> Starmap<I, F, A>
+    where I: Iterator<Item=A>,
+{
+    pub fn new(iter: I, f: F) -> Self {
+        Starmap {
+            iter: iter,
+            f: f,
+        }
+    }
+}
+
+macro_rules! starmap_iterator {
+    ($a:ident, $($b:ident,)+) => {
+        starmap_iterator!($($b,)*);
+        impl<I, F, R, $a, $($b),*> Iterator for Starmap<I, F, ($a, $($b),*)>
+            where I: Iterator<Item=($a, $($b),*)>,
+                  F: FnMut($a, $($b),*) -> R,
+        {
+            type Item = R;
+            #[allow(non_snake_case)]
+            fn next(&mut self) -> Option<R> {
+                let f = &mut self.f;
+                self.iter.next().map(|($a, $($b),*)| f($a, $($b),*))
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.iter.size_hint()
+            }
+        }
+        impl<I, F, R, $a, $($b),*> DoubleEndedIterator for Starmap<I, F, ($a, $($b),*)>
+            where I: DoubleEndedIterator<Item=($a, $($b),*)>,
+                  F: FnMut($a, $($b),*) -> R,
+        {
+            #[allow(non_snake_case)]
+            fn next_back(&mut self) -> Option<R> {
+                let f = &mut self.f;
+                self.iter.next_back().map(|($a, $($b),*)| f($a, $($b),*))
+            }
+        }
+    };
+    ($a:ident, ) => {
+        // no impl for Item=A
+    }
+}
+
+starmap_iterator!{A_, B_, C_, D_, E_, F_, G_, H_, }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub use adaptors::{
     Unique,
     UniqueBy,
     Flatten,
+    Starmap,
 };
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "unstable", deprecated(note = "Uses deprecated libstd traits"))]
@@ -936,6 +937,13 @@ pub trait Itertools : Iterator {
         where Self: Sized
     {
         self.map(f)
+    }
+
+    fn starmap<F>(self, f: F) -> Starmap<Self, F, Self::Item>
+        where Self: Sized,
+              Starmap<Self, F, Self::Item>: Iterator
+    {
+        Starmap::new(self, f)
     }
 
     // non-adaptor methods

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -993,3 +993,12 @@ fn format() {
     let t3 = format!("{:.2e}", dataf.iter().format_default(", "));
     assert_eq!(t3, "1.10e0, 2.72e0, -2.20e1");
 }
+
+#[test]
+fn starmap() {
+    it::assert_equal((0..10).zip(0..10).starmap(|x, y| x + y),
+                     (0..10).map(|x| x * 2));
+
+    it::assert_equal(Zip::new((0..5, 1..5, 2..5)).starmap(|x, y, z| (x, y, z)),
+                     vec![(0, 1, 2), (1, 2, 3), (2, 3, 4)]);
+}


### PR DESCRIPTION
.starmap() takes an iterator of n-tuples and allows applying an n-ary closure to it.

For example: `multizip((0..5, 1..5, 2..5)).starmap(|x, y, z| x + y + z)`
