### PR TITLE
minmax_by takes FnMut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1514,7 +1514,7 @@ pub trait Itertools : Iterator {
     fn minmax(self) -> MinMaxResult<Self::Item>
         where Self: Sized, Self::Item: Ord
     {
-        minmax::minmax_impl(self, |_| (), |x, y, _, _| x < y, |x, y, _, _| x > y)
+        minmax::minmax_impl(self, |_| (), |x, y, _, _| x < y)
     }
 
     /// Return the minimum and maximum element of an iterator, as determined by
@@ -1528,7 +1528,7 @@ pub trait Itertools : Iterator {
     fn minmax_by_key<K, F>(self, f: F) -> MinMaxResult<Self::Item>
         where Self: Sized, K: Ord, F: FnMut(&Self::Item) -> K
     {
-        minmax::minmax_impl(self, f, |_, _, xk, yk| xk < yk, |_, _, xk, yk| xk > yk)
+        minmax::minmax_impl(self, f, |_, _, xk, yk| xk < yk)
     }
 
     /// Return the minimum and maximum element of an iterator, as determined by
@@ -1539,14 +1539,13 @@ pub trait Itertools : Iterator {
     /// For the minimum, the first minimal element is returned.  For the maximum,
     /// the last maximal element wins.  This matches the behavior of the standard
     /// `Iterator::min()` and `Iterator::max()` methods.
-    fn minmax_by<F>(self, compare: F) -> MinMaxResult<Self::Item>
-        where Self: Sized, F: Fn(&Self::Item, &Self::Item) -> Ordering
+    fn minmax_by<F>(self, mut compare: F) -> MinMaxResult<Self::Item>
+        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
     {
         minmax::minmax_impl(
             self,
             |_| (),
-            |x, y, _, _| Ordering::Less == compare(x, y),
-            |x, y, _, _| Ordering::Greater == compare(x, y)
+            |x, y, _, _| Ordering::Less == compare(x, y)
         )
     }
 }

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -46,11 +46,10 @@ impl<T: Clone> MinMaxResult<T> {
 }
 
 /// Implementation guts for `minmax` and `minmax_by_key`.
-pub fn minmax_impl<I: Itertools, K, F, L, G>(mut it: I, mut key_for: F,
-                                             lt: L, gt: G) -> MinMaxResult<I::Item>
+pub fn minmax_impl<I: Itertools, K, F, L>(mut it: I, mut key_for: F,
+                                             mut lt: L) -> MinMaxResult<I::Item>
     where I: Sized, F: FnMut(&I::Item) -> K,
-          L: Fn(&I::Item, &I::Item, &K, &K) -> bool,
-          G: Fn(&I::Item, &I::Item, &K, &K) -> bool
+          L: FnMut(&I::Item, &I::Item, &K, &K) -> bool,
 {
     let (mut min, mut max, mut min_key, mut max_key) = match it.next() {
         None => return MinMaxResult::NoElements,
@@ -60,7 +59,7 @@ pub fn minmax_impl<I: Itertools, K, F, L, G>(mut it: I, mut key_for: F,
                 Some(y) => {
                     let xk = key_for(&x);
                     let yk = key_for(&y);
-                    if !gt(&x, &y, &xk, &yk) {(x, y, xk, yk)} else {(y, x, yk, xk)}
+                    if !lt(&y, &x, &yk, &xk) {(x, y, xk, yk)} else {(y, x, yk, xk)}
                 }
             }
         }
@@ -90,7 +89,7 @@ pub fn minmax_impl<I: Itertools, K, F, L, G>(mut it: I, mut key_for: F,
         };
         let first_key = key_for(&first);
         let second_key = key_for(&second);
-        if !gt(&first, &second, &first_key, &second_key) {
+        if !lt(&second, &first, &second_key, &first_key) {
             if lt(&first, &min, &first_key, &min_key) {
                 min = first;
                 min_key = first_key;


### PR DESCRIPTION
`minmax_impl` took two comparison functions: less-than and greater-than. This is not necessary as far as I can see, since we can argue `less_than(x,y)=greater_than(y,x)`. If we changed `minmax_impl` to take only one comparison function, we could circumvent the `FnMut` borrowing issue.