### PR TITLE
Improve .step() slightly and add itertools::free::cloned

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -11,9 +11,11 @@ use itertools::Itertools;
 use itertools::{ZipTrusted};
 
 use itertools::ZipSlices;
+use itertools::free::cloned;
 
 use std::iter::repeat;
 use std::cmp;
+use std::ops::Add;
 
 #[bench]
 fn slice_iter(b: &mut test::Bencher)
@@ -699,13 +701,19 @@ fn kmerge_tenway(b: &mut test::Bencher) {
 }
 
 
+fn fast_integer_sum<I>(iter: I) -> I::Item
+    where I: IntoIterator,
+          I::Item: Default + Add<Output=I::Item>
+{
+    iter.into_iter().fold(<_>::default(), |x, y| x + y)
+}
 
 
 #[bench]
 fn step_vec_2(b: &mut test::Bencher) {
     let v = vec![0; 1024];
     b.iter(|| {
-        v.iter().step(2).sum::<i32>()
+        fast_integer_sum(cloned(v.iter().step(2)))
     });
 }
 
@@ -713,6 +721,22 @@ fn step_vec_2(b: &mut test::Bencher) {
 fn step_vec_10(b: &mut test::Bencher) {
     let v = vec![0; 1024];
     b.iter(|| {
-        v.iter().step(10).sum::<i32>()
+        fast_integer_sum(cloned(v.iter().step(10)))
+    });
+}
+
+#[bench]
+fn step_range_2(b: &mut test::Bencher) {
+    let v = black_box(0..1024);
+    b.iter(|| {
+        fast_integer_sum(v.clone().step(2))
+    });
+}
+
+#[bench]
+fn step_range_10(b: &mut test::Bencher) {
+    let v = black_box(0..1024);
+    b.iter(|| {
+        fast_integer_sum(v.clone().step(10))
     });
 }

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -14,7 +14,6 @@ use std::ops::Index;
 use std::iter::{Fuse, Peekable, FlatMap};
 use std::collections::HashSet;
 use std::hash::Hash;
-use Itertools;
 use size_hint;
 use misc::MendSlice;
 
@@ -503,7 +502,9 @@ impl<I> Iterator for Step<I>
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
         let elt = self.iter.next();
-        self.iter.dropn(self.skip);
+        if self.skip > 0 {
+            self.iter.nth(self.skip - 1);
+        }
         elt
     }
 

--- a/src/free.rs
+++ b/src/free.rs
@@ -106,6 +106,22 @@ pub fn chain<I, J>(i: I, j: J) -> iter::Chain<<I as IntoIterator>::IntoIter, <J 
     i.into_iter().chain(j)
 }
 
+/// Create an iterator that clones each element from &T to T
+///
+/// `IntoIterator` enabled version of `i.cloned()`.
+///
+/// ```
+/// use itertools::free::cloned;
+///
+/// assert_eq!(cloned(b"abc").next(), Some(b'a'));
+/// ```
+pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
+    where I: IntoIterator<Item=&'a T>,
+          T: Clone,
+{
+    iterable.into_iter().cloned()
+}
+
 /// Perform a fold operation over the iterable.
 ///
 /// `IntoIterator` enabled version of `i.fold(init, f)`

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -1,4 +1,3 @@
-use Itertools;
 
 /// `MinMaxResult` is an enum returned by `minmax`. See `Itertools::minmax()` for
 /// more detail.

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -237,6 +237,31 @@ quickcheck! {
         correct_size_hint(filt.step(s)) &&
             exact_size(a.step(s))
     }
+    fn equal_step(a: Iter<i16>, s: usize) -> bool {
+        let mut s = s;
+        if s == 0 {
+            s += 1; // never zero
+        }
+        let mut i = 0;
+        itertools::equal(a.clone().step(s), a.filter(|_| {
+            let keep = i % s == 0;
+            i += 1;
+            keep
+        }))
+    }
+    fn equal_step_vec(a: Vec<i16>, s: usize) -> bool {
+        let mut s = s;
+        if s == 0 {
+            s += 1; // never zero
+        }
+        let mut i = 0;
+        itertools::equal(a.iter().step(s), a.iter().filter(|_| {
+            let keep = i % s == 0;
+            i += 1;
+            keep
+        }))
+    }
+
     fn size_multipeek(a: Iter<u16>, s: u8) -> bool {
         let mut it = a.multipeek();
         // peek a few times


### PR DESCRIPTION
- cloned is an intoiterator version of .cloned()
- step is improved slightly for specialized fuse (takes advantage of .nth())

Related to #133, but only minor changes, no revolution, according to the bench.