### PR TITLE
Fix performance of iteration over an multipeek adaptor

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::mem::replace;
 use std::ops::Index;
 use std::iter::{Fuse, Peekable};
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::hash::Hash;
 use std::marker::PhantomData;
 use size_hint;
@@ -697,7 +697,7 @@ pub struct MultiPeek<I>
     where I: Iterator
 {
     iter: Fuse<I>,
-    buf: Vec<I::Item>,
+    buf: VecDeque<I::Item>,
     index: usize,
 }
 
@@ -708,7 +708,7 @@ pub fn multipeek<I>(iterable: I) -> MultiPeek<I::IntoIter>
 {
     MultiPeek {
         iter: iterable.into_iter().fuse(),
-        buf: Vec::new(),
+        buf: VecDeque::new(),
         index: 0,
     }
 }
@@ -723,7 +723,7 @@ impl<I: Iterator> MultiPeek<I> {
         } else {
             match self.iter.next() {
                 Some(x) => {
-                    self.buf.push(x);
+                    self.buf.push_back(x);
                     Some(&self.buf[self.index])
                 }
                 None => return None,
@@ -745,7 +745,7 @@ impl<I> Iterator for MultiPeek<I>
         if self.buf.is_empty() {
             self.iter.next()
         } else {
-            Some(self.buf.remove(0))
+            self.buf.pop_front()
         }
     }
 


### PR DESCRIPTION
In case of calling peek often, the buffering vector will become large.
In those case each iteration step will copy all but the first element of
the vector one element to the right. Using a VecDeque fixes this
behaviour.


Code to reproduce this issue on master:
```rust
extern crate itertools;
use std::time::Instant;

const MAX: usize = 1_000_000;


fn main() {
    let data = (0..MAX).collect::<Vec<_>>();

    let mut mp = itertools::multipeek(data.into_iter());
    let mut counter_1 = 0;
    let start1 = Instant::now();
    while let Some(p) = mp.peek() {
        counter_1 += *p;
    }
    println!("Iterating using peek: {:?} -> {}",
             start1.elapsed(),
             counter_1);
    let mut counter_2 = 0;
    let start2 = Instant::now();
    for d in mp {
        counter_2 += d;
    }
    println!("Iterating using iterator: {:?} -> {}",
             start2.elapsed(),
             counter_2);
    assert_eq!(counter_1, counter_2);
}
```