### PR TITLE
A peeking version of take while; .peeking_take_while()

### DIFF
--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -1,0 +1,106 @@
+
+use std::iter::Peekable;
+use PutBack;
+use PutBackN;
+
+/// An iterator that allows peeking at an element before deciding
+/// to accept it.
+///
+/// See [`.peeking_take_while()`](trait.Itertools.html#method.peeking_take_while)
+/// for more information.
+pub trait PeekingNext : Iterator {
+    /// Pass a reference to the next iterator element to the closure `accept`;
+    /// if `accept` returns true, return it as the next element,
+    /// else None.
+    fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
+        where F: FnOnce(&Self::Item) -> bool;
+}
+
+impl<I> PeekingNext for Peekable<I>
+    where I: Iterator,
+{
+    fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
+        where F: FnOnce(&Self::Item) -> bool
+    {
+        if let Some(r) = self.peek() {
+            if !accept(r) {
+                return None;
+            }
+        }
+        self.next()
+    }
+}
+
+impl<I> PeekingNext for PutBack<I>
+    where I: Iterator,
+{
+    fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
+        where F: FnOnce(&Self::Item) -> bool
+    {
+        if let Some(r) = self.next() {
+            if !accept(&r) {
+                self.put_back(r);
+                return None;
+            }
+            Some(r)
+        } else {
+            None
+        }
+    }
+}
+
+impl<I> PeekingNext for PutBackN<I>
+    where I: Iterator,
+{
+    fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
+        where F: FnOnce(&Self::Item) -> bool
+    {
+        if let Some(r) = self.next() {
+            if !accept(&r) {
+                self.put_back(r);
+                return None;
+            }
+            Some(r)
+        } else {
+            None
+        }
+    }
+}
+
+/// An iterator adaptor that takes items while a closure returns `true`.
+///
+/// See [`.peeking_take_while()`](../trait.Itertools.html#method.peeking_take_while)
+/// for more information.
+pub struct PeekingTakeWhile<'a, I: 'a, F>
+    where I: Iterator,
+{
+    iter: &'a mut I,
+    f: F,
+}
+
+/// Create a PeekingTakeWhile
+pub fn peeking_take_while<I, F>(iter: &mut I, f: F) -> PeekingTakeWhile<I, F>
+    where I: Iterator,
+{
+    PeekingTakeWhile {
+        iter: iter,
+        f: f,
+    }
+}
+
+impl<'a, I, F> Iterator for PeekingTakeWhile<'a, I, F>
+    where I: PeekingNext,
+          F: FnMut(&I::Item) -> bool,
+
+{
+    type Item = I::Item;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.peeking_next(&mut self.f)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, hi) = self.iter.size_hint();
+        (0, hi)
+    }
+}
+

--- a/tests/peeking_take_while.rs
+++ b/tests/peeking_take_while.rs
@@ -1,0 +1,33 @@
+
+extern crate itertools;
+
+use itertools::Itertools;
+use itertools::{put_back, put_back_n};
+
+#[test]
+fn peeking_take_while_peekable() {
+    let mut r = (0..10).peekable();
+    r.peeking_take_while(|x| *x <= 3).count();
+    assert_eq!(r.next(), Some(4));
+}
+
+#[test]
+fn peeking_take_while_put_back() {
+    let mut r = put_back(0..10);
+    r.peeking_take_while(|x| *x <= 3).count();
+    assert_eq!(r.next(), Some(4));
+    r.peeking_take_while(|_| true).count();
+    assert_eq!(r.next(), None);
+}
+
+#[test]
+fn peeking_take_while_put_back_n() {
+    let mut r = put_back_n(6..10);
+    for elt in (0..6).rev() {
+        r.put_back(elt);
+    }
+    r.peeking_take_while(|x| *x <= 3).count();
+    assert_eq!(r.next(), Some(4));
+    r.peeking_take_while(|_| true).count();
+    assert_eq!(r.next(), None);
+}

--- a/tests/peeking_take_while.rs
+++ b/tests/peeking_take_while.rs
@@ -31,3 +31,23 @@ fn peeking_take_while_put_back_n() {
     r.peeking_take_while(|_| true).count();
     assert_eq!(r.next(), None);
 }
+
+#[test]
+fn peeking_take_while_slice_iter() {
+    let v = [1, 2, 3, 4, 5, 6];
+    let mut r = v.iter();
+    r.peeking_take_while(|x| **x <= 3).count();
+    assert_eq!(r.next(), Some(&4));
+    r.peeking_take_while(|_| true).count();
+    assert_eq!(r.next(), None);
+}
+
+#[test]
+fn peeking_take_while_slice_iter_rev() {
+    let v = [1, 2, 3, 4, 5, 6];
+    let mut r = v.iter().rev();
+    r.peeking_take_while(|x| **x >= 3).count();
+    assert_eq!(r.next(), Some(&2));
+    r.peeking_take_while(|_| true).count();
+    assert_eq!(r.next(), None);
+}


### PR DESCRIPTION
This is like .take_while(), except the last item that we didn't want to take, remains in the underlying peekable / put back.

Also adds new trait `PeekingNext` which makes this extensible.