### PR TITLE
Replace kmerge binary heap with std library binary heap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 version = "0.2"
 
 [features]
+nightly = []
 
 [profile]
 bench = { debug = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 #![crate_name="itertools"]
+#![cfg_attr(feature = "nightly", feature(binary_heap_peek_mut_pop))]
 
 //! Itertools — extra iterator adaptors, functions and macros.
 //!


### PR DESCRIPTION
Hi all, I'm Proposing to switch kmerge back to the original author's use of BinaryHeap, but make use of features to give the same (theoretical) efficiency of the recent versions: don't pop and push, just sort_down after reading an element out of the top iterator using PeekMut.

A new [feature](https://github.com/rust-lang/rust/commit/f2cb47adf95171e48a9f918aae00193a7d36c7c0) in nightly adds the ability to pop the top instead of sorting down, for when the iterator is empty.

This PR includes two versions of `KMerge::next()` : one using the `PeekMut::pop()` feature and one without.
Build with `cargo build --features nightly` to use the new feature.

The good new and bad news:
```
bash-3.2$ cargo benchcmp perf.local perf.stdlib | grep kmerge
 kmerge_default                6,108               17,788                     11,680  191.22% 
 kmerge_tenway                 268,831             272,354                     3,523    1.31% 
```

The bad news is some situations get much worse.  The good news is that this puts pressure on the std libcollections/binary_heap.rs to possibly improve as:
1. putting the local version of sort_down into a locally built std lib got most of the perf back.
2. In PeekMut::drop(), putting a precondition to only call sort_down if the tip would actually move got half of the performance back (with no change to sort_down).
The test case has long vectors that sometime have sequences. The local version of sort_down does no writes (swap) until something moves. The std library version has some writes even if nothing moves.

Any more analysis is beyond the scope of this fix, as it relates to altering the std library.
Thanks.
