### PR TITLE
Add iter! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ test = false
 
 [dependencies]
 either = { version = "1.0", default-features = false }
+nodrop = "0.1.8"
 
 [dev-dependencies.quickcheck]
 version = "0.4"

--- a/benches/list_iterator.rs
+++ b/benches/list_iterator.rs
@@ -1,0 +1,124 @@
+#![feature(test)]
+
+#[macro_use]
+extern crate itertools;
+extern crate test;
+
+use std::cmp::max;
+
+#[inline]
+pub fn _max3<T: Ord>(a: T, b: T, c: T) -> T {
+    max(max(a, b), c)
+}
+
+#[inline]
+pub fn _max4<T: Ord>(a: T, b: T, c: T, d: T) -> T {
+    max(_max3(a, b, c), d)
+}
+
+#[inline]
+pub fn _max5<T: Ord>(a: T, b: T, c: T, d: T, e: T) -> T {
+    max(_max4(a, b, c, d), e)
+}
+
+fn gen_vec() -> Vec<usize> {
+    (0..1024).collect()
+}
+
+#[bench]
+fn max2(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 2 {
+            s = s.wrapping_add(max(x[i], x[i + 1]));
+        }
+        s
+    })
+}
+
+#[bench]
+fn max3(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 3 {
+            s = s.wrapping_add(_max3(x[i], x[i + 1], x[i + 2]));
+        }
+        s
+    })
+}
+
+#[bench]
+fn max4(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 4 {
+            s = s.wrapping_add(_max4(x[i], x[i + 1], x[i + 2], x[i + 3]));
+        }
+        s
+    })
+}
+
+#[bench]
+fn max5(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 5 {
+            s = s.wrapping_add(_max5(x[i], x[i + 1], x[i + 2], x[i + 3], x[i + 4]));
+        }
+        s
+    })
+}
+
+#[bench]
+fn max2_iter(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 2 {
+            s = s.wrapping_add(iter!(x[i], x[i + 1]).max().unwrap());
+        }
+        s
+    })
+}
+
+#[bench]
+fn max3_iter(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 3 {
+            s = s.wrapping_add(iter!(x[i], x[i + 1], x[i + 2]).max().unwrap());
+        }
+        s
+    })
+}
+
+#[bench]
+fn max4_iter(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 4 {
+            s = s.wrapping_add(iter!(x[i], x[i + 1], x[i + 2], x[i + 3]).max().unwrap());
+        }
+        s
+    })
+}
+
+#[bench]
+fn max5_iter(b: &mut test::Bencher) {
+    let x = gen_vec();
+    b.iter(|| {
+        let mut s = 0usize;
+        for i in 0..x.len() - 5 {
+            s = s.wrapping_add(iter!(x[i], x[i + 1], x[i + 2], x[i + 3], x[i + 4])
+                .max()
+                .unwrap());
+        }
+        s
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 #![doc(html_root_url="https://docs.rs/itertools/")]
 
 extern crate either;
+extern crate nodrop;
 
 pub use either::Either;
 
@@ -73,7 +74,7 @@ pub mod structs {
     pub use peeking_take_while::PeekingTakeWhile;
     pub use rciter_impl::RcIter;
     pub use repeatn::RepeatN;
-    pub use sources::{RepeatCall, Unfold, Iterate};
+    pub use sources::{RepeatCall, Unfold, Iterate, ListIterator};
     pub use tee::Tee;
     pub use tuple_impl::{TupleBuffer, TupleWindows, Tuples};
     pub use with_position::WithPosition;
@@ -88,7 +89,7 @@ pub use diff::Diff;
 pub use minmax::MinMaxResult;
 pub use peeking_take_while::PeekingNext;
 pub use repeatn::repeat_n;
-pub use sources::{repeat_call, unfold, iterate};
+pub use sources::{repeat_call, unfold, iterate, list_iterator};
 pub use with_position::Position;
 pub use zip_longest::EitherOrBoth;
 pub use ziptuple::multizip;
@@ -148,6 +149,30 @@ macro_rules! iproduct {
     );
     ($I:expr, $J:expr, $($K:expr),+) => (
         iproduct!(@flatten iproduct!($I, $J), $($K,)+)
+    );
+}
+
+#[macro_export]
+/// Create an iterator over the specified items.
+///
+/// ```
+/// #[macro_use] extern crate itertools;
+/// # fn main() {
+/// let mut it = iter![5, 3];
+/// assert_eq!(Some(5), it.next());
+/// assert_eq!(Some(3), it.next());
+/// assert_eq!(None, it.next());
+///
+/// assert_eq!(Some(10), itertools::max(iter![2, 10, 5, 1, 3]));
+///
+/// for x in iter![4, 10, 12] {
+///     // do stuff
+/// }
+/// # }
+/// ```
+macro_rules! iter {
+    ($($X:expr),*) => (
+        $crate::list_iterator([$($X),*])
     );
 }
 


### PR DESCRIPTION
A temporary solution for the missing `IntoIterator` implementation for `[T; N]` (https://github.com/rust-lang/rust/issues/25725). While I was finishing this PR another issue was opened https://github.com/rust-lang/rust/issues/39257.

When `IntoIterator` get implemented for `[T; N]` an user can port their code removing the `iter!` macro invocations.

My main use case for this is to use the free functions in `itertools`, like `max`, with an arbitrary number of elements. The benchmarks show no difference for `maxN(a, b, ...)` and `max(iter!(a, b, ...))`.

This introduces a dependency on `nodrop`.