### PR TITLE
Add .kmerge_by()

### DIFF
--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -307,6 +307,44 @@ quickcheck! {
         merged.sort();
         itertools::equal(merged.into_iter(), kmerge(inputs))
     }
+
+    // Any number of input iterators
+    fn equal_kmerge_by_ge(mut inputs: Vec<Vec<i16>>) -> bool {
+        // sort the inputs
+        for input in &mut inputs {
+            input.sort();
+            input.reverse();
+        }
+        let mut merged = inputs.concat();
+        merged.sort();
+        merged.reverse();
+        itertools::equal(merged.into_iter(),
+                         inputs.into_iter().kmerge_by(|x, y| x >= y))
+    }
+
+    // Any number of input iterators
+    fn equal_kmerge_by_lt(mut inputs: Vec<Vec<i16>>) -> bool {
+        // sort the inputs
+        for input in &mut inputs {
+            input.sort();
+        }
+        let mut merged = inputs.concat();
+        merged.sort();
+        itertools::equal(merged.into_iter(),
+                         inputs.into_iter().kmerge_by(|x, y| x < y))
+    }
+
+    // Any number of input iterators
+    fn equal_kmerge_by_le(mut inputs: Vec<Vec<i16>>) -> bool {
+        // sort the inputs
+        for input in &mut inputs {
+            input.sort();
+        }
+        let mut merged = inputs.concat();
+        merged.sort();
+        itertools::equal(merged.into_iter(),
+                         inputs.into_iter().kmerge_by(|x, y| x <= y))
+    }
     fn size_kmerge(a: Iter<i16>, b: Iter<i16>, c: Iter<i16>) -> bool {
         use itertools::free::kmerge;
         correct_size_hint(kmerge(vec![a, b, c]))


### PR DESCRIPTION
The heap implementation is bespoke. (We could possibly have used
libstd's BinaryHeap but not before PeekMut's pop goes stable).

Change the heap implementation to use an ordering closure. Also change
its default formulation to be a min-heap (ordering lesser objects
first). Also relax constraints to use PartialOrd.

The usual thinking is that it should be the user's choice how strict
they want to be about Ord, not our place to restrict; kmerge only needs
“is a before b?”.

The chosen formulation for .kmerge_by() is to take a closure
`first: FnMut(&T, &T) -> bool`. By default this is the less than operator,
if that makes it clear.

Fixes #191 