### PR TITLE
Implement breaking changes for next version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 matrix:
   include:
-    - rust: 1.11.0
+    - rust: 1.12.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Itertools
 =========
 
-Extra iterator adaptors, functions and macros. Requires Rust 1.11 or later.
+Extra iterator adaptors, functions and macros.
 
 Please read the `API documentation here`__
 

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1155,7 +1155,6 @@ impl<I> fmt::Debug for Combinations<I>
 pub fn combinations<I>(iter: I, n: usize) -> Combinations<I>
     where I: Iterator
 {
-    assert!(n != 0);
     let mut indices: Vec<usize> = Vec::with_capacity(n);
     for i in 0..n {
         indices.push(i);
@@ -1191,6 +1190,8 @@ impl<I> Iterator for Combinations<I>
 
         if self.first {
             self.first = false;
+        } else if self.n == 0 {
+            return None;
         } else {
             // Scan from the end, looking for an index to increment
             let mut i: usize = self.n - 1;

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -193,16 +193,6 @@ pub fn put_back<I>(iterable: I) -> PutBack<I::IntoIter>
 impl<I> PutBack<I>
     where I: Iterator
 {
-    #[doc(hidden)]
-    #[deprecated(note = "replaced by put_back")]
-    #[inline]
-    pub fn new(it: I) -> Self {
-        PutBack {
-            top: None,
-            iter: it,
-        }
-    }
-
     /// put back value `value` (builder method)
     pub fn with_value(mut self, value: I::Item) -> Self {
         self.put_back(value);
@@ -288,21 +278,14 @@ pub fn put_back_n<I>(iterable: I) -> PutBackN<I::IntoIter>
 }
 
 impl<I: Iterator> PutBackN<I> {
-    #[doc(hidden)]
-    #[deprecated(note = "replaced by put_back_n")]
-    #[inline]
-    pub fn new(it: I) -> Self {
-        put_back_n(it)
-    }
-
     /// Puts x in front of the iterator.
     /// The values are yielded in order of the most recently put back
     /// values first.
     ///
     /// ```rust
-    /// use itertools::PutBackN;
+    /// use itertools::put_back_n;
     ///
-    /// let mut it = PutBackN::new(1..5);
+    /// let mut it = put_back_n(1..5);
     /// it.next();
     /// it.put_back(1);
     /// it.put_back(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1330,18 +1330,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!((0..10).fold1(|x, y| x + y).unwrap_or(0), 45);
     /// assert_eq!((0..0).fold1(|x, y| x * y), None);
     /// ```
-    fn fold1<F>(&mut self, mut f: F) -> Option<Self::Item>
-        where F: FnMut(Self::Item, Self::Item) -> Self::Item
+    fn fold1<F>(mut self, f: F) -> Option<Self::Item>
+        where F: FnMut(Self::Item, Self::Item) -> Self::Item,
+              Self: Sized,
     {
-        match self.next() {
-            None => None,
-            Some(mut x) => {
-                for y in self {
-                    x = f(x, y);
-                }
-                Some(x)
-            }
-        }
+        self.next().map(move |x| self.fold(x, f))
     }
 
     /// An iterator method that applies a function, producing a single, final value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -909,17 +909,18 @@ pub trait Itertools : Iterator {
 
     /// Unravel a nested iterator.
     ///
-    /// This is a shortcut for `it.flat_map(|x| x)`.
+    /// This is more or less equivalent to `.flat_map` with an identity
+    /// function.
     ///
     /// ```
     /// use itertools::Itertools;
     ///
     /// let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
-    /// let flattened = data.into_iter().flatten();
+    /// let flattened = data.iter().flatten();
     ///
-    /// itertools::assert_equal(flattened, vec![1, 2, 3, 4, 5, 6]);
+    /// itertools::assert_equal(flattened, &[1, 2, 3, 4, 5, 6]);
     /// ```
-    fn flatten(self) -> Flatten<Self, <<Self as Iterator>::Item as IntoIterator>::IntoIter>
+    fn flatten(self) -> Flatten<Self, <Self::Item as IntoIterator>::IntoIter>
         where Self: Sized,
               Self::Item: IntoIterator
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,10 +621,10 @@ pub trait Itertools : Iterator {
     /// let it = vec![a, b, c].into_iter().kmerge();
     /// itertools::assert_equal(it, vec![0, 1, 2, 3, 4, 5]);
     /// ```
-    fn kmerge(self) -> KMerge<<<Self as Iterator>::Item as IntoIterator>::IntoIter>
+    fn kmerge(self) -> KMerge<<Self::Item as IntoIterator>::IntoIter>
         where Self: Sized,
               Self::Item: IntoIterator,
-              <<Self as Iterator>::Item as IntoIterator>::Item: PartialOrd,
+              <Self::Item as IntoIterator>::Item: PartialOrd,
     {
         kmerge(self)
     }
@@ -650,11 +650,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(it.last(), Some(-7.));
     /// ```
     fn kmerge_by<F>(self, first: F)
-        -> KMergeBy<<<Self as Iterator>::Item as IntoIterator>::IntoIter, F>
+        -> KMergeBy<<Self::Item as IntoIterator>::IntoIter, F>
         where Self: Sized,
               Self::Item: IntoIterator,
-              F: FnMut(&<<Self as Iterator>::Item as IntoIterator>::Item,
-                       &<<Self as Iterator>::Item as IntoIterator>::Item) -> bool
+              F: FnMut(&<Self::Item as IntoIterator>::Item,
+                       &<Self::Item as IntoIterator>::Item) -> bool
     {
         kmerge_by(self, first)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,15 +361,6 @@ pub trait Itertools : Iterator {
         groupbylazy::new(self, key)
     }
 
-    ///
-    #[deprecated(note = "renamed to .group_by()")]
-    fn group_by_lazy<K, F>(self, key: F) -> GroupBy<K, Self, F>
-        where Self: Sized,
-              F: FnMut(&Self::Item) -> K,
-    {
-        self.group_by(key)
-    }
-
     /// Return an *iterable* that can chunk the iterator.
     ///
     /// Yield subiterators (chunks) that each yield a fixed number elements,
@@ -402,14 +393,6 @@ pub trait Itertools : Iterator {
     {
         assert!(size != 0);
         groupbylazy::new_chunks(self, size)
-    }
-
-    ///
-    #[deprecated(note = "renamed to .chunks()")]
-    fn chunks_lazy(self, size: usize) -> IntoChunks<Self>
-        where Self: Sized,
-    {
-        self.chunks(size)
     }
 
     /// Return an iterator over all contiguous windows producing tuples of
@@ -1170,14 +1153,6 @@ pub trait Itertools : Iterator {
     ///            "1.10, 2.72, -3.00");
     /// ```
     fn format(self, sep: &str) -> Format<Self>
-        where Self: Sized,
-    {
-        format::new_format_default(self, sep)
-    }
-
-    ///
-    #[deprecated(note = "renamed to .format()")]
-    fn format_default(self, sep: &str) -> Format<Self>
         where Self: Sized,
     {
         format::new_format_default(self, sep)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,8 +888,6 @@ pub trait Itertools : Iterator {
     /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new Vec per iteration,
     /// and clones the iterator elements.
     ///
-    /// **Panics** if `n` is zero.
-    ///
     /// ```
     /// use itertools::Itertools;
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1087,11 +1087,10 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal(rx.iter(), vec![1, 3, 5, 7, 9]);
     /// ```
-    fn foreach<F>(&mut self, mut f: F)
-        where F: FnMut(Self::Item)
+    fn foreach<F>(self, mut f: F)
+        where F: FnMut(Self::Item),
+              Self: Sized,
     {
-        // FIXME: This use of fold doesn't actually do any iterator
-        // specific traversal (fold requries `self`)
         self.fold((), move |(), element| f(element))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,9 @@
 //! #[macro_use] extern crate itertools;
 //! ```
 //!
-//! ## License
-//! Dual-licensed to be compatible with the Rust project.
+//! ## Rust Version
 //!
-//! Licensed under the Apache License, Version 2.0
-//! http://www.apache.org/licenses/LICENSE-2.0 or the MIT license
-//! http://opensource.org/licenses/MIT, at your
-//! option. This file may not be copied, modified, or distributed
-//! except according to those terms.
-//!
+//! This version of itertools requires Rust 1.12 or later.
 //!
 #![doc(html_root_url="https://docs.rs/itertools/")]
 

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -112,8 +112,6 @@ impl<'a, I, F> Iterator for PeekingTakeWhile<'a, I, F>
 macro_rules! peeking_next_by_clone {
     (@as_item $x:item) => ($x);
     ([$($typarm:tt)*] $type_:ty) => {
-        // FIXME: Ast coercion is dead as soon as we can dep on Rust 1.12
-        peeking_next_by_clone! { @as_item
         impl<$($typarm)*> PeekingNext for $type_ {
             fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
                 where F: FnOnce(&Self::Item) -> bool
@@ -128,7 +126,6 @@ macro_rules! peeking_next_by_clone {
                 }
                 None
             }
-        }
         }
     }
 }

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -18,23 +18,6 @@ pub fn repeat_n<A>(element: A, n: usize) -> RepeatN<A>
     }
 }
 
-impl<A> RepeatN<A> {
-    #[deprecated(note = "The ::new constructor is deprecated. Use `repeat_n`")]
-    ///
-    pub fn new(elt: A, n: usize) -> Self {
-        // The code is duplicated here because the new version uses
-        // the proper A: Clone bound.
-        if n == 0 {
-            RepeatN { elt: None, n: n }
-        } else {
-            RepeatN {
-                elt: Some(elt),
-                n: n,
-            }
-        }
-    }
-}
-
 impl<A> Iterator for RepeatN<A>
     where A: Clone
 {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -179,7 +179,6 @@ macro_rules! quickcheck {
     // The property functions can use pattern matching and `mut` as usual
     // in the function arguments, but the functions can not be generic.
     {$($(#$attr:tt)* fn $fn_name:ident($($arg:tt)*) -> $ret:ty { $($code:tt)* })*} => (
-        quickcheck!{@as_items
         $(
             #[test]
             $(#$attr)*
@@ -190,11 +189,10 @@ macro_rules! quickcheck {
                 ::quickcheck::quickcheck(quickcheck!(@fn prop [] $($arg)*));
             }
         )*
-        }
     );
     // parse argument list (with patterns allowed) into prop as fn(_, _) -> _
     (@fn $f:ident [$($t:tt)*]) => {
-        quickcheck!(@as_expr $f as fn($($t),*) -> _)
+        $f as fn($($t),*) -> _
     };
     (@fn $f:ident [$($p:tt)*] : $($tail:tt)*) => {
         quickcheck!(@fn $f [$($p)* _] $($tail)*)
@@ -202,8 +200,6 @@ macro_rules! quickcheck {
     (@fn $f:ident [$($p:tt)*] $t:tt $($tail:tt)*) => {
         quickcheck!(@fn $f [$($p)*] $($tail)*)
     };
-    (@as_items $($i:item)*) => ($($i)*);
-    (@as_expr $i:expr) => ($i);
 }
 
 quickcheck! {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -420,10 +420,6 @@ quickcheck! {
         itertools::equal(a.iter().flatten(),
                          a.iter().flat_map(|x| x))
     }
-    fn equal_flatten_vec_rev(a: Vec<Vec<u8>>) -> bool {
-        itertools::equal(a.iter().flatten().rev(),
-                         a.iter().flat_map(|x| x).rev())
-    }
 
     fn equal_combinations_2(a: Vec<u8>) -> bool {
         let mut v = Vec::new();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -770,10 +770,9 @@ fn combinations_of_too_short() {
 }
 
 
-#[should_panic]
 #[test]
 fn combinations_zero() {
-    (1..3).combinations(0);
+    it::assert_equal((1..3).combinations(0), vec![vec![]]);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -828,7 +828,7 @@ fn fold_while() {
         } else {
             FoldWhile::Done(acc)
         }
-    });
+    }).into_inner();
     assert_eq!(iterations, 6);
     assert_eq!(sum, 15);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -702,13 +702,6 @@ fn flatten_iter() {
 }
 
 #[test]
-fn flatten_rev() {
-    let data = vec![vec![1,2,3].into_iter(), vec![4,5,6].into_iter()];
-    let flattened = data.into_iter().flatten().rev();
-    it::assert_equal(flattened, vec![6,5,4,3,2,1]);
-}
-
-#[test]
 fn flatten_clone() {
     let data = &[
         &[1,2,3],


### PR DESCRIPTION
- combinations #174 
- flatten #161 
- deprecated constructors #157 
- fold while #168 
- `self` for foreach and fold1 #167 

Submodule `itertools::free::` is still used in different places, and it is deprecated (use itertools:: directly) but we won't remove it. First figure out how to even mark those deprecated at all.