### PR TITLE
New iterator adapter allowing feedback loops

### DIFF
--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,0 +1,74 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+mod inner {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    pub struct Inner<T>(pub Rc<Cell<Option<T>>>);
+
+    impl<T: Copy> Iterator for Inner<T> {
+        type Item = T;
+
+        fn next(&mut self) -> Option<T> {
+            self.0.get()
+        }
+    }
+}
+
+/// See [`feedback`](../fn.feedback.html) for more information.
+pub struct Feedback<I, T> {
+    iter: I,
+    inner: Rc<Cell<Option<T>>>,
+}
+
+/**
+ * Feed the output of an iterator pipeline back to the input. Feedback
+ * is delayed by one timestep to preserve causality, so the first input
+ * is provided by `initial`, and the output of that pass is used as the
+ * input for the second pass, and so on.
+ *
+ * Every time the input is requested, it yields the last result returned
+ * by the pipeline. The pipeline can request the feedback value any
+ * number of times per cycle, including ignoring it entirely. If the
+ * pipeline doesn't request a particular input, that input is discarded,
+ * not saved for the next cycle. If the pipeline requests an input
+ * multiple times in the process of producing an output, the same input
+ * will be returned each time.
+ *
+ * ```rust
+ * use itertools::feedback;
+ * let input = [1, -2, 3, -4, 5];
+ * let result: Vec<i32> = feedback(0, |feedback|
+ *         feedback.zip(&input)
+ *                 .map(|(a, b)| a + b)
+ *     ).collect();
+ * assert_eq!(result, &[0, 1, -1, 2, -2, 3]);
+ * ```
+ */
+pub fn feedback<F, I, T>(initial: T, inner: F) -> Feedback<I, T>
+    where F: FnOnce(inner::Inner<T>) -> I,
+          T: Copy
+{
+    let initial = Rc::new(Cell::new(Some(initial)));
+    Feedback {
+        iter: inner(inner::Inner(initial.clone())),
+        inner: initial,
+    }
+}
+
+impl<I, T> Iterator for Feedback<I, T>
+    where I: Iterator<Item = T>,
+          T: Copy
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if let Some(v) = self.inner.get() {
+            self.inner.set(self.iter.next());
+            Some(v)
+        } else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod structs {
         Flatten,
     };
     pub use cons_tuples_impl::ConsTuples;
+    pub use feedback::Feedback;
     pub use format::{Format, FormatWith};
     pub use groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use intersperse::Intersperse;
@@ -79,6 +80,7 @@ pub use structs::*;
 pub use cons_tuples_impl::cons_tuples;
 pub use diff::diff_with;
 pub use diff::Diff;
+pub use feedback::feedback;
 pub use kmerge_impl::{kmerge_by};
 pub use minmax::MinMaxResult;
 pub use peeking_take_while::PeekingNext;
@@ -94,6 +96,7 @@ pub mod free;
 pub use free::*;
 mod cons_tuples_impl;
 mod diff;
+mod feedback;
 mod format;
 mod groupbylazy;
 mod intersperse;


### PR DESCRIPTION
I want to be able to express cyclic graphs of iterator adapters (with a one-cycle delay at every back-edge, to preserve causality) so I wrote some Rust to do it, and `itertools` seems like a natural home for it. My use-case is for digital signal processing, but I think this captures a general dataflow pattern that isn't covered by other iterator tools.

My simple example from the doctest:

```rust
use itertools::feedback;
let input = [1, -2, 3, -4, 5];
let result: Vec<i32> = feedback(0, |feedback|
        feedback.zip(&input)
                .map(|(a, b)| a + b)
    ).collect();
assert_eq!(result, &[0, 1, -1, 2, -2, 3]);
```

I have some concerns about my implementation so I'll understand if you don't want to just merge it. :smile:

1. `feedback` takes a callback whose job is to construct the inner pipeline of iterator adapters. At the head of that pipeline is an iterator provided by the `feedback` function itself. The type of that iterator should not be exposed to users of the library, but it has a concrete type and I want the callers to get monomorphized using the actual type so everything can be inlined appropriately. I'm currently using the approach documented in https://github.com/rust-lang/rust/issues/34537#issue-162798003 to use a private type in the public API without compiler warnings or errors, but that feels like a hack. Is there a better option?

2. I _think_ we can prove statically that the lifetime of the internal `Rc` is bounded by the lifetime of the `Feedback`, so this shouldn't need an `Rc` or even any heap allocation. But I'm not sure how to convince the compiler. This at least seems unlikely to change public API, so I think it doesn't matter whether it's fixed before merging.

3. There might well be another way to do this, though I couldn't find it. I considered both `Iterator::scan` and `itertools::unfold`, but neither one lets me construct the inner dataflow graph by composing other iterator adapters.

4. This could probably stand to have more tests than just the doctest, but I'm not sure what they should cover.

Thoughts? Thanks!