### PR TITLE
Replace RefCell with Cell in Format and FormatWith

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::cell::RefCell;
+use std::cell::Cell;
 
 /// Format all iterator elements lazily, separated by `sep`.
 ///
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 pub struct FormatWith<'a, I, F> {
     sep: &'a str,
     /// FormatWith uses interior mutability because Display::fmt takes &self.
-    inner: RefCell<Option<(I, F)>>,
+    inner: Cell<Option<(I, F)>>,
 }
 
 /// Format all iterator elements lazily, separated by `sep`.
@@ -20,11 +20,24 @@ pub struct FormatWith<'a, I, F> {
 ///
 /// See [`.format()`](../trait.Itertools.html#method.format)
 /// for more information.
-#[derive(Clone)]
 pub struct Format<'a, I> {
     sep: &'a str,
     /// Format uses interior mutability because Display::fmt takes &self.
-    inner: RefCell<Option<I>>,
+    inner: Cell<Option<I>>,
+}
+
+impl<'a, I: Clone> Clone for Format<'a, I> {
+    fn clone(&self) -> Self {
+        Format {
+            sep: self.sep,
+            inner: Cell::new(
+                self.inner.take().map(|iter| {
+                    self.inner.set(Some(iter.clone()));
+                    iter
+                })
+            )
+        }
+    }
 }
 
 pub fn new_format<'a, I, F>(iter: I, separator: &'a str, f: F) -> FormatWith<'a, I, F>
@@ -33,7 +46,7 @@ pub fn new_format<'a, I, F>(iter: I, separator: &'a str, f: F) -> FormatWith<'a,
 {
     FormatWith {
         sep: separator,
-        inner: RefCell::new(Some((iter, f))),
+        inner: Cell::new(Some((iter, f))),
     }
 }
 
@@ -42,7 +55,7 @@ pub fn new_format_default<'a, I>(iter: I, separator: &'a str) -> Format<'a, I>
 {
     Format {
         sep: separator,
-        inner: RefCell::new(Some(iter)),
+        inner: Cell::new(Some(iter)),
     }
 }
 
@@ -51,7 +64,7 @@ impl<'a, I, F> fmt::Display for FormatWith<'a, I, F>
           F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let (mut iter, mut format) = match self.inner.borrow_mut().take() {
+        let (mut iter, mut format) = match self.inner.take() {
             Some(t) => t,
             None => panic!("FormatWith: was already formatted once"),
         };
@@ -76,7 +89,7 @@ impl<'a, I> Format<'a, I>
     fn format<F>(&self, f: &mut fmt::Formatter, mut cb: F) -> fmt::Result
         where F: FnMut(&I::Item, &mut fmt::Formatter) -> fmt::Result,
     {
-        let mut iter = match self.inner.borrow_mut().take() {
+        let mut iter = match self.inner.take() {
             Some(t) => t,
             None => panic!("Format: was already formatted once"),
         };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -889,4 +889,10 @@ fn format() {
     let dataf = [1.1, 2.71828, -22.];
     let t3 = format!("{:.2e}", dataf.iter().format(", "));
     assert_eq!(t3, "1.10e0, 2.72e0, -2.20e1");
+
+    let f = data.iter().format(", ");
+    let t4c = format!("{}", f.clone());
+    let t4 = format!("{}", f);
+    assert_eq!(t4c, ans1);
+    assert_eq!(t4, ans1);
 }


### PR DESCRIPTION
I've been playing around with iterators, using itertools as reference, and found unnecessary RefCells in Format and FormatWith structs. There isn't that much overhead, but why not throw it off if possible? Also, alternative Clone implementation and test for that.
My first pull request for Rust project, please take care of me.