### PR TITLE
Inexact size hint testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 Cargo.lock
+/.idea/
+/*.iml

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -379,12 +379,12 @@ impl<I, J> Iterator for Product<I, J>
     fn size_hint(&self) -> (usize, Option<usize>) {
         let has_cur = self.a_cur.is_some() as usize;
         // Not ExactSizeIterator because size may be larger than usize
-        let (b, _) = self.b.size_hint();
+        let (b_min, b_max) = self.b.size_hint();
 
         // Compute a * b_orig + b for both lower and upper bound
-        size_hint::add_scalar(
+        size_hint::add(
             size_hint::mul(self.a.size_hint(), self.b_orig.size_hint()),
-            b * has_cur)
+            (b_min * has_cur, b_max.map(move |x| x * has_cur)))
     }
 }
 

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -77,6 +77,6 @@ impl<I, F> DoubleEndedIterator for PadUsing<I, F>
 }
 
 impl<I, F> ExactSizeIterator for PadUsing<I, F>
-    where I: Iterator,
+    where I: ExactSizeIterator,
           F: FnMut(usize) -> I::Item
 {}

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -65,6 +65,15 @@ pub fn mul(a: SizeHint, b: SizeHint) -> SizeHint {
     (low, hi)
 }
 
+/// Multiply **x** correctly with a **SizeHint**.
+#[inline]
+pub fn mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
+    let (mut low, mut hi) = sh;
+    low = low.saturating_mul(x);
+    hi = hi.and_then(|elt| elt.checked_mul(x));
+    (low, hi)
+}
+
 /// Return the maximum
 #[inline]
 pub fn max(a: SizeHint, b: SizeHint) -> SizeHint {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -107,7 +107,7 @@ impl qc::Arbitrary for Inexact {
 /// At the end it will return None once, then return Some(0),
 /// then return None again.
 #[derive(Clone, Debug)]
-struct Iter<T, SK: HintKind = Exact> {
+struct Iter<T, SK: HintKind = Inexact> {
     iterator: Range<T>,
     // fuse/done flag
     fuse_flag: i32,
@@ -299,7 +299,7 @@ quickcheck! {
         correct_size_hint(iproduct!(a, b, c))
     }
 
-    fn size_step(a: Iter<i16>, s: usize) -> bool {
+    fn size_step(a: Iter<i16, Exact>, s: usize) -> bool {
         let mut s = s;
         if s == 0 {
             s += 1; // never zero
@@ -333,7 +333,7 @@ quickcheck! {
         }))
     }
 
-    fn size_multipeek(a: Iter<u16>, s: u8) -> bool {
+    fn size_multipeek(a: Iter<u16, Exact>, s: u8) -> bool {
         let mut it = multipeek(a);
         // peek a few times
         for _ in 0..s {
@@ -355,7 +355,7 @@ quickcheck! {
     fn size_merge(a: Iter<u16>, b: Iter<u16>) -> bool {
         correct_size_hint(a.merge(b))
     }
-    fn size_zip(a: Iter<i16>, b: Iter<i16>, c: Iter<i16>) -> bool {
+    fn size_zip(a: Iter<i16, Exact>, b: Iter<i16, Exact>, c: Iter<i16, Exact>) -> bool {
         let filt = a.clone().dedup();
         correct_size_hint(multizip((filt, b.clone(), c.clone()))) &&
             exact_size(multizip((a, b, c)))
@@ -439,7 +439,7 @@ quickcheck! {
         let b = &b[..len];
         itertools::equal(zip_eq(a, b), zip(a, b))
     }
-    fn size_zip_longest(a: Iter<i16>, b: Iter<i16>) -> bool {
+    fn size_zip_longest(a: Iter<i16, Exact>, b: Iter<i16, Exact>) -> bool {
         let filt = a.clone().dedup();
         let filt2 = b.clone().dedup();
         correct_size_hint(filt.zip_longest(b.clone())) &&
@@ -468,7 +468,7 @@ quickcheck! {
     fn size_interleave(a: Iter<i16>, b: Iter<i16>) -> bool {
         correct_size_hint(a.interleave(b))
     }
-    fn exact_interleave(a: Iter<i16>, b: Iter<i16>) -> bool {
+    fn exact_interleave(a: Iter<i16, Exact>, b: Iter<i16, Exact>) -> bool {
         exact_size_for_this(a.interleave(b))
     }
     fn size_interleave_shortest(a: Iter<i16>, b: Iter<i16>) -> bool {
@@ -778,7 +778,7 @@ quickcheck! {
     fn with_position_exact_size_1(a: Vec<u8>) -> bool {
         exact_size_for_this(a.iter().with_position())
     }
-    fn with_position_exact_size_2(a: Iter<u8>) -> bool {
+    fn with_position_exact_size_2(a: Iter<u8, Exact>) -> bool {
         exact_size_for_this(a.with_position())
     }
 }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -628,7 +628,7 @@ quickcheck! {
 }
 
 quickcheck! {
-    fn size_pad_tail2(it: Iter<i8>, pad: u8) -> bool {
+    fn size_pad_tail2(it: Iter<i8, Exact>, pad: u8) -> bool {
         exact_size(it.pad_using(pad as usize, |_| 0))
     }
 }


### PR DESCRIPTION
This extends the existing test iterator with a mode that returns inexact size hints randomly. When generated by `Arbitrary` with the `Inexact` type parameter, `Iter` will now under / overestimate its lower / upper bounds, so we can test the size hints more thoroughly.

The new tests failed in 4 cases, caused by 2 `size_hint` implementation bugs (wrong upper bound in `Product`, overflow in `InterleaveShortest`) and a bad trait constraint for `PadUsing`. I fixed them all, but the fix for `PadUsing` is a breaking change.