### PR TITLE
Implement concat method

### DIFF
--- a/src/concat_impl.rs
+++ b/src/concat_impl.rs
@@ -1,0 +1,13 @@
+use Itertools;
+
+/// Concatenate all items of the iterator into a single extendable destination.
+///
+/// This combinator will extend the first item with the contents of the rest
+/// of the items of the iterator. If the iterator is empty, the default value
+/// will be returned.
+pub fn concat<I: Iterator>(iter: I) -> I::Item
+    where I: Iterator,
+          I::Item: Extend<<<I as Iterator>::Item as IntoIterator>::Item> + IntoIterator + Default
+{
+    iter.fold1(|mut a, b| { a.extend(b); a }).unwrap_or_else(|| <_>::default())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub mod structs {
         UniqueBy,
         Flatten,
     };
+    pub use concat_impl::concat;
     pub use cons_tuples_impl::ConsTuples;
     pub use format::{Format, FormatWith};
     pub use groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
@@ -92,6 +93,7 @@ mod adaptors;
 pub mod free;
 #[doc(inline)]
 pub use free::*;
+mod concat_impl;
 mod cons_tuples_impl;
 mod diff;
 mod format;
@@ -1090,6 +1092,18 @@ pub trait Itertools : Iterator {
               Self: Sized,
     {
         self.fold((), move |(), element| f(element))
+    }
+
+    /// Concatenate all items of the iterator into a single extendable destination.
+    ///
+    /// This combinator will extend the first item with the contents of the rest
+    /// of the items of the iterator. If the iterator is empty, the default value
+    /// will be returned.
+    fn concat(self) -> Self::Item
+        where Self: Sized,
+              Self::Item: Extend<<<Self as Iterator>::Item as IntoIterator>::Item> + IntoIterator + Default
+    {
+        concat(self)
     }
 
     /// `.collect_vec()` is simply a type specialization of `.collect()`,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -703,6 +703,18 @@ fn chunks() {
 }
 
 #[test]
+fn concat_empty() {
+    let data: Vec<Vec<()>> = Vec::new();
+    assert_eq!(data.into_iter().concat(), Vec::new())
+}
+
+#[test]
+fn concat_non_empty() {
+    let data = vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]];
+    assert_eq!(data.into_iter().concat(), vec![1,2,3,4,5,6,7,8,9])
+}
+
+#[test]
 fn flatten_iter() {
     let data = vec![vec![1,2,3], vec![4,5,6]];
     let flattened = data.into_iter().flatten();


### PR DESCRIPTION
Implements a `concat` method to mirror the [`Stream::concat2`](https://docs.rs/futures/0.1.14/futures/stream/trait.Stream.html#method.concat2) method from the [futures](https://github.com/alexcrichton/futures-rs) library.