### PR TITLE
Implement izip! using .zip()s and single tupple-flattening .map()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,8 @@ macro_rules! iproduct {
 /// returns `None`.
 ///
 /// Iterator element type is like `(A, B, ..., E)` if formed
-/// from iterators `(I, J, ..., M)` implementing `I: Iterator<A>`,
-/// `J: Iterator<B>`, ..., `M: Iterator<E>`
+/// from iterators `(I, J, ..., M)` implementing `I: IntoIterator<Item=A>`,
+/// `J: IntoIterator<Item=B>`, ..., `M: IntoIterator<Item=E>`
 ///
 /// ```
 /// #[macro_use] extern crate itertools;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,14 +174,27 @@ macro_rules! iproduct {
 /// # }
 /// ```
 macro_rules! izip {
-    ($I:expr) => (
-        (::std::iter::IntoIterator::into_iter($I))
-    );
-    ($($I:expr),*) => (
-        {
-            $crate::multizip(($(izip!($I)),*))
-        }
-    );
+    // @closure creates a tuple-flattening closure for .map() call. usage:
+    // @closure partial_pattern => partial_tuple , rest , of , iterators
+    // eg. izip!( @closure ((a, b), c) => (a, b, c) , dd , ee )
+    ( @closure $p:pat => $tup:expr ) => {
+        |$p| $tup
+    };
+
+    // The "b" identifier is a different identifier on each recursion level thanks to hygiene.
+    ( @closure $p:pat => ( $($tup:tt)* ) , $_iter:expr $( , $tail:expr )* ) => {
+        izip!(@closure ($p, b) => ( $($tup)*, b ) $( , $tail )*)
+    };
+
+    ( $first:expr $( , $rest:expr )* $(,)* ) => {
+        ::std::iter::IntoIterator::into_iter($first)
+            $(
+                .zip($rest)
+            )*
+            .map(
+                izip!(@closure a => (a) $( , $rest )*)
+            )
+    };
 }
 
 /// The trait `Itertools`: extra iterator adaptors and methods for iterators.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -60,6 +60,10 @@ fn product_temporary() {
 
 #[test]
 fn izip_macro() {
+    let mut zip = izip!(2..3);
+    assert!(zip.next() == Some(2));
+    assert!(zip.next().is_none());
+
     let mut zip = izip!(0..3, 0..2, 0..2i8);
     for i in 0..2 {
         assert!((i as usize, i, i as i8) == zip.next().unwrap());


### PR DESCRIPTION
This should *probably* enable vectorization-friendly specializations from `std`.

In theory, it's a breaking change, since it no longer returns `multizip::Zip`.