### PR TITLE
Remove unneeded mut qualifiers

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -217,7 +217,7 @@ fn batching() {
     let ys = [(0, 1), (2, 1)];
 
     // An iterator that gathers elements up in pairs
-    let pit = xs.iter().cloned().batching(|mut it| {
+    let pit = xs.iter().cloned().batching(|it| {
                match it.next() {
                    None => None,
                    Some(x) => match it.next() {
@@ -323,7 +323,7 @@ fn trait_pointers() {
 
     {
         /* make sure foreach works on non-Sized */
-        let mut jt: &mut Iterator<Item=i32> = &mut *it;
+        let jt: &mut Iterator<Item = i32> = &mut *it;
         assert_eq!(jt.next(), Some(1));
 
         {

--- a/tests/zip.rs
+++ b/tests/zip.rs
@@ -5,12 +5,11 @@ use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::free::zip_eq;
 
 #[test]
-fn zip_longest_fused()
-{
+fn zip_longest_fused() {
     let a = [Some(1), None, Some(3), Some(4)];
     let b = [1, 2, 3];
 
-    let unfused = a.iter().batching(|mut it| *it.next().unwrap())
+    let unfused = a.iter().batching(|it| *it.next().unwrap())
         .zip_longest(b.iter().cloned());
     itertools::assert_equal(unfused,
                        vec![Both(1, 1), Right(2), Right(3)]);


### PR DESCRIPTION
I feel like I'm missing something obvious here, but I ran `cargo build` `cargo test` `cargo doc` on 1.19 and 1.21.0-nightly (f25c2283b 2017-08-15) and it worked in all those cases...

How are these unneeded?