### PR TITLE
Implement .fold() for .cartesian_product() and cons_tuples()

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
 extern crate test;
-extern crate itertools;
+#[macro_use] extern crate itertools;
 
 use test::{black_box};
 use itertools::Itertools;
@@ -648,4 +648,56 @@ fn step_range_10(b: &mut test::Bencher) {
     b.iter(|| {
         fast_integer_sum(v.clone().step(10))
     });
+}
+
+#[bench]
+fn cartesian_product_iterator(b: &mut test::Bencher)
+{
+    let xs = vec![0; 16];
+
+    b.iter(|| {
+        let mut sum = 0;
+        for (&x, &y, &z) in iproduct!(&xs, &xs, &xs) {
+            sum += x;
+            sum += y;
+            sum += z;
+        }
+        sum
+    })
+}
+
+#[bench]
+fn cartesian_product_fold(b: &mut test::Bencher)
+{
+    let xs = vec![0; 16];
+
+    b.iter(|| {
+        let mut sum = 0;
+        iproduct!(&xs, &xs, &xs).fold((), |(), (&x, &y, &z)| {
+            sum += x;
+            sum += y;
+            sum += z;
+        });
+        sum
+    })
+}
+
+#[bench]
+fn cartesian_product_nested_for(b: &mut test::Bencher)
+{
+    let xs = vec![0; 16];
+
+    b.iter(|| {
+        let mut sum = 0;
+        for &x in &xs {
+            for &y in &xs {
+                for &z in &xs {
+                    sum += x;
+                    sum += y;
+                    sum += z;
+                }
+            }
+        }
+        sum
+    })
 }

--- a/src/cons_tuples_impl.rs
+++ b/src/cons_tuples_impl.rs
@@ -16,6 +16,11 @@ macro_rules! impl_cons_iter(
             fn size_hint(&self) -> (usize, Option<usize>) {
                 self.iter.size_hint()
             }
+            fn fold<Acc, Fold>(self, accum: Acc, mut f: Fold) -> Acc
+                where Fold: FnMut(Acc, Self::Item) -> Acc,
+            {
+                self.iter.fold(accum, move |acc, (($($B,)*), x)| f(acc, ($($B,)* x, )))
+            }
         }
 
         #[allow(non_snake_case)]

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -299,6 +299,25 @@ quickcheck! {
         correct_size_hint(iproduct!(a, b, c))
     }
 
+    fn correct_cartesian_product3(a: Iter<u16>, b: Iter<u16>, c: Iter<u16>,
+                                  take_manual: usize) -> ()
+    {
+        // test correctness of iproduct through regular iteration (take)
+        // and through fold.
+        let ac = a.clone();
+        let br = &b.clone();
+        let cr = &c.clone();
+        let answer: Vec<_> = ac.flat_map(move |ea| br.clone().flat_map(move |eb| cr.clone().map(move |ec| (ea, eb, ec)))).collect();
+        let mut product_iter = iproduct!(a, b, c);
+        let mut actual = Vec::new();
+
+        actual.extend((&mut product_iter).take(take_manual));
+        if actual.len() == take_manual {
+            product_iter.fold((), |(), elt| actual.push(elt));
+        }
+        assert_eq!(answer, actual);
+    }
+
     fn size_step(a: Iter<i16, Exact>, s: usize) -> bool {
         let mut s = s;
         if s == 0 {


### PR DESCRIPTION
Internal iteration recovers "nested loop performance" of products --
usable through .foreach() as well (soon stable Rust .for_each()).

```
test cartesian_product_fold                   ... bench:       1,054 ns/iter (+/- 12)
test cartesian_product_iterator               ... bench:       5,279 ns/iter (+/- 248)
test cartesian_product_nested_for             ... bench:       1,000 ns/iter (+/- 33)
```

Fixes #221