### PR TITLE
Add PartialEq trait bounds to IterTools::group_by

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,7 @@ pub trait Itertools : Iterator {
     fn group_by<K, F>(self, key: F) -> GroupBy<K, Self, F>
         where Self: Sized,
               F: FnMut(&Self::Item) -> K,
+	      K: PartialEq,
     {
         groupbylazy::new(self, key)
     }


### PR DESCRIPTION
Closes #224

Merge this pull request whenever the next round of breaking changes occur.