### PR TITLE
Add new adaptor .merge_join_by()

### DIFF
--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -1,0 +1,10 @@
+/// Value that either holds a single A or B, or both.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum EitherOrBoth<A, B> {
+    /// Both values are present.
+    Both(A, B),
+    /// Only the left value of type `A` is present.
+    Left(A),
+    /// Only the right value of type `B` is present.
+    Right(B),
+}

--- a/src/free.rs
+++ b/src/free.rs
@@ -21,6 +21,7 @@ pub use multipeek_impl::multipeek;
 #[cfg(feature = "use_std")]
 pub use kmerge_impl::kmerge;
 pub use zip_eq_impl::zip_eq;
+pub use merge_join::merge_join_by;
 #[cfg(feature = "use_std")]
 pub use rciter_impl::rciter;
 

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -1,0 +1,75 @@
+use std::cmp::Ordering;
+use std::iter::Fuse;
+
+use super::adaptors::{PutBack, put_back};
+use either_or_both::EitherOrBoth;
+
+/// Return an iterator adaptor that merge-joins items from the two base iterators in ascending order.
+///
+/// See [`.merge_join_by()`](trait.Itertools.html#method.merge_join_by) for more information.
+pub fn merge_join_by<I, J, F>(left: I, right: J, cmp_fn: F) -> MergeJoinBy<I, J, F>
+    where I: IntoIterator,
+          J: IntoIterator,
+          F: FnMut(&I::Item, &J::Item) -> Ordering
+{
+    MergeJoinBy {
+        left: put_back(left.into_iter().fuse()),
+        right: put_back(right.into_iter().fuse()),
+        cmp_fn: cmp_fn
+    }
+}
+
+/// An iterator adaptor that merge-joins items from the two base iterators in ascending order.
+///
+/// See [`.merge_join_by()`](../trait.Itertools.html#method.merge_join_by) for more information.
+pub struct MergeJoinBy<I: IntoIterator, J: IntoIterator, F> {
+    left: PutBack<Fuse<I::IntoIter>>,
+    right: PutBack<Fuse<J::IntoIter>>,
+    cmp_fn: F
+}
+
+impl<I, J, F> Iterator for MergeJoinBy<I, J, F>
+    where I: IntoIterator,
+          J: IntoIterator,
+          F: FnMut(&I::Item, &J::Item) -> Ordering
+{
+    type Item = EitherOrBoth<I::Item, J::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.left.next(), self.right.next()) {
+            (None, None) => None,
+            (Some(left), None) =>
+                Some(EitherOrBoth::Left(left)),
+            (None, Some(right)) =>
+                Some(EitherOrBoth::Right(right)),
+            (Some(left), Some(right)) => {
+                match (self.cmp_fn)(&left, &right) {
+                    Ordering::Equal =>
+                        Some(EitherOrBoth::Both(left, right)),
+                    Ordering::Less => {
+                        self.right.put_back(right);
+                        Some(EitherOrBoth::Left(left))
+                    },
+                    Ordering::Greater => {
+                        self.left.put_back(left);
+                        Some(EitherOrBoth::Right(right))
+                    }
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (a_lower, a_upper) = self.left.size_hint();
+        let (b_lower, b_upper) = self.right.size_hint();
+
+        let lower = ::std::cmp::max(a_lower, b_lower);
+
+        let upper = match (a_upper, b_upper) {
+            (Some(x), Some(y)) => Some(x + y),
+            _ => None,
+        };
+
+        (lower, upper)
+    }
+}

--- a/tests/merge_join.rs
+++ b/tests/merge_join.rs
@@ -1,0 +1,110 @@
+extern crate itertools;
+
+use itertools::EitherOrBoth;
+use itertools::free::merge_join_by;
+
+#[test]
+fn empty() {
+    let left: Vec<u32> = vec![];
+    let right: Vec<u32> = vec![];
+    let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![];
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn left_only() {
+    let left: Vec<u32> = vec![1,2,3];
+    let right: Vec<u32> = vec![];
+    let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
+        EitherOrBoth::Left(1),
+        EitherOrBoth::Left(2),
+        EitherOrBoth::Left(3)
+    ];
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn right_only() {
+    let left: Vec<u32> = vec![];
+    let right: Vec<u32> = vec![1,2,3];
+    let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
+        EitherOrBoth::Right(1),
+        EitherOrBoth::Right(2),
+        EitherOrBoth::Right(3)
+    ];
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn first_left_then_right() {
+    let left: Vec<u32> = vec![1,2,3];
+    let right: Vec<u32> = vec![4,5,6];
+    let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
+        EitherOrBoth::Left(1),
+        EitherOrBoth::Left(2),
+        EitherOrBoth::Left(3),
+        EitherOrBoth::Right(4),
+        EitherOrBoth::Right(5),
+        EitherOrBoth::Right(6)
+    ];
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn first_right_then_left() {
+    let left: Vec<u32> = vec![4,5,6];
+    let right: Vec<u32> = vec![1,2,3];
+    let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
+        EitherOrBoth::Right(1),
+        EitherOrBoth::Right(2),
+        EitherOrBoth::Right(3),
+        EitherOrBoth::Left(4),
+        EitherOrBoth::Left(5),
+        EitherOrBoth::Left(6)
+    ];
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn interspersed_left_and_right() {
+    let left: Vec<u32> = vec![1,3,5];
+    let right: Vec<u32> = vec![2,4,6];
+    let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
+        EitherOrBoth::Left(1),
+        EitherOrBoth::Right(2),
+        EitherOrBoth::Left(3),
+        EitherOrBoth::Right(4),
+        EitherOrBoth::Left(5),
+        EitherOrBoth::Right(6)
+    ];
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn overlapping_left_and_right() {
+    let left: Vec<u32> = vec![1,3,4,6];
+    let right: Vec<u32> = vec![2,3,4,5];
+    let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
+        EitherOrBoth::Left(1),
+        EitherOrBoth::Right(2),
+        EitherOrBoth::Both(3, 3),
+        EitherOrBoth::Both(4, 4),
+        EitherOrBoth::Right(5),
+        EitherOrBoth::Left(6)
+    ];
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}


### PR DESCRIPTION
Noticed I was re-implementing something similar to this combinator in many projects, so I thought it might be worth making it reusable!

The combinator takes two iterators and merges/zips their items in ascending order. It's useful  in many contexts to implement merge behaviours with linear time complexity, including but not limited to:

- Determining the causal order of two vector clocks
- Merging timestamp-ordered streams of events, cross-referencing events with the same timestamp
- Zipping two heterogenous maps or trees (think merging `Map<K, A>` and `Map<K, B>` into `Map<K, (A, B)>`)

Let me know what you think!