### PR TITLE
FEAT: implement .update()

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1192,3 +1192,62 @@ impl<I, F> DoubleEndedIterator for Positions<I, F>
     }
 }
 
+/// An iterator adapter to apply a mutating function to each element before yielding it.
+///
+/// See [`.update()`](../trait.Itertools.html#method.update) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct Update<I, F> {
+    iter: I,
+    f: F,
+}
+
+/// Create a new `Update` iterator.
+pub fn update<I, F>(iter: I, f: F) -> Update<I, F>
+where
+    I: Iterator,
+    F: FnMut(&mut I::Item),
+{
+    Update { iter: iter, f: f }
+}
+
+impl<I, F> Iterator for Update<I, F>
+where
+    I: Iterator,
+    F: FnMut(&mut I::Item),
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(mut v) = self.iter.next() {
+            (self.f)(&mut v);
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<I, F> ExactSizeIterator for Update<I, F>
+where
+    I: ExactSizeIterator,
+    F: FnMut(&mut I::Item),
+{}
+
+impl<I, F> DoubleEndedIterator for Update<I, F>
+where
+    I: DoubleEndedIterator,
+    F: FnMut(&mut I::Item),
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if let Some(mut v) = self.iter.next_back() {
+            (self.f)(&mut v);
+            Some(v)
+        } else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod structs {
         TupleCombinations,
         Flatten,
         Positions,
+        Update,
     };
     #[cfg(feature = "use_std")]
     pub use combinations::Combinations;
@@ -1109,6 +1110,23 @@ pub trait Itertools : Iterator {
               P: FnMut(Self::Item) -> bool,
     {
         adaptors::positions(self, predicate)
+    }
+
+    /// Return an iterator adaptor that applies a mutating function
+    /// to each element before yielding it.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let input = vec![vec![1], vec![3, 2, 1]];
+    /// let it = input.into_iter().update(|mut v| v.push(0));
+    /// itertools::assert_equal(it, vec![vec![1, 0], vec![3, 2, 1, 0]]);
+    /// ```
+    fn update<F>(self, updater: F) -> Update<Self, F>
+        where Self: Sized,
+              F: FnMut(&mut Self::Item),
+    {
+        adaptors::update(self, updater)
     }
 
     // non-adaptor methods


### PR DESCRIPTION
Closes #231.

Adds the following method on Itertools:

```rust
pub trait Itertools : Iterator {
    { ... }
    fn shuffle<F>(self, buffer_size: usize, shuffler: F) -> Shuffle<Self, F> 
    where
        Self: Sized,
        Self::Item: PartialEq,
        F: FnMut(&mut Vec<Self::Item>), 
    { ... }
}
```

Shuffles portions of the iterator by collecting items into a buffer of a given size and calling a shuffling function on that buffer.

```rust
use itertools::Itertools;

let data = vec![0, 1, 2, 3, 4, 5, 6];
let shuffled = data.into_iter().shuffle(2, |v| v.reverse());
itertools::assert_equal(shuffled,
                        vec![1, 0, 3, 2, 5, 4, 6]);
```

You can use the rand crate to randomly shuffle the buffer:

```rust
extern crate rand;

use itertools::Itertools;
use rand::Rng;

let shuffle = |v: &mut Vec<_>| rand::thread_rng().shuffle(v.as_mut_slice());
let data = vec![0, 1, 4, 7, 2, 9, 5];
let shuffled: Vec<_> = data.iter().shuffle(8, shuffle).collect();
// e.g. -> [4, 5, 0, 7, 9, 1, 2]
```