### PR TITLE
Add collect_tuple method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1132,6 +1132,37 @@ pub trait Itertools : Iterator {
         T::collect_from_iter_no_buf(self)
     }
 
+    /// Collects all items from the iterator into a tuple of
+    /// a specific size (up to 4).
+    ///
+    /// If number of elements inside iterator is exactly equal to the
+    /// tuple size, then the tuple is returned inside `Some`, otherwise
+    /// `None` is returned.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let iter = 1..3;
+    ///
+    /// if let Some((x, y)) = iter.collect_tuple() {
+    ///     assert_eq!((x, y), (1, 2))
+    /// } else {
+    ///     panic!("Expected two elements")
+    /// }
+    /// ```
+    fn collect_tuple<T>(mut self) -> Option<T>
+        where Self: Sized + Iterator<Item = T::Item>,
+              T: tuple_impl::TupleCollect
+    {
+        match self.next_tuple() {
+            Some(tuple) => match self.next() {
+                Some(_) => None,
+                None => Some(tuple),
+            },
+            _ => None
+        }
+    }
+
 
     /// Find the position and value of the first element satisfying a predicate.
     ///

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -101,7 +101,7 @@ impl qc::Arbitrary for Inexact {
 /// Our base iterator that we can impl Arbitrary for
 ///
 /// By default we'll return inexact bounds estimates for size_hint
-/// to make tests harder ro pass.
+/// to make tests harder to pass.
 ///
 /// NOTE: Iter is tricky and is not fused, to help catch bugs.
 /// At the end it will return None once, then return Some(0),
@@ -537,6 +537,11 @@ quickcheck! {
             }
         }
         itertools::equal(cloned(&a).tuple_combinations::<(_, _)>(), cloned(&v))
+    }
+
+    fn collect_tuple_matches_size(a: Iter<i16>) -> bool {
+        let size = a.clone().count();
+        a.collect_tuple::<(_, _, _)>().is_some() == (size == 3)
     }
 }
 

--- a/tests/tuples.rs
+++ b/tests/tuples.rs
@@ -71,3 +71,18 @@ fn next_tuple() {
     assert_eq!(iter.next_tuple().map(|(&x, &y)| (x, y)), Some((3, 4)));
     assert_eq!(iter.next_tuple::<(_, _)>(), None);
 }
+
+#[test]
+fn collect_tuple() {
+    let v = [1, 2];
+    let iter = v.iter().cloned();
+    assert_eq!(iter.collect_tuple(), Some((1, 2)));
+
+    let v = [1];
+    let iter = v.iter().cloned();
+    assert_eq!(iter.collect_tuple::<(_, _)>(), None);
+
+    let v = [1, 2, 3];
+    let iter = v.iter().cloned();
+    assert_eq!(iter.collect_tuple::<(_, _)>(), None);
+}


### PR DESCRIPTION
Hi! This adds a consuming method `unpack_tuple`, which destructs the iterator into a tuple of specific size, making sure there are no extra items. This is useful, for example, for parsing related code, when you want to coerce unstructured data into a specific form, and mirrors Python's unpacking idiom:

```
(a, b) = input().split()  # makes sure we've got exactly two words
```

You sort-of can use `.next_tuple()` for this, but you may leave some extra input, which is often a cause of subtle bugs.