### PR TITLE
Itertools::multi_cartesian_product

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -683,6 +683,38 @@ fn cartesian_product_fold(b: &mut test::Bencher)
 }
 
 #[bench]
+fn multi_cartesian_product_iterator(b: &mut test::Bencher)
+{
+    let xs = [vec![0; 16], vec![0; 16], vec![0; 16]];
+
+    b.iter(|| {
+        let mut sum = 0;
+        for x in xs.into_iter().multi_cartesian_product() {
+            sum += x[0];
+            sum += x[1];
+            sum += x[2];
+        }
+        sum
+    })
+}
+
+#[bench]
+fn multi_cartesian_product_fold(b: &mut test::Bencher)
+{
+    let xs = [vec![0; 16], vec![0; 16], vec![0; 16]];
+
+    b.iter(|| {
+        let mut sum = 0;
+        xs.into_iter().multi_cartesian_product().fold((), |(), x| {
+            sum += x[0];
+            sum += x[1];
+            sum += x[2];
+        });
+        sum
+    })
+}
+
+#[bench]
 fn cartesian_product_nested_for(b: &mut test::Bencher)
 {
     let xs = vec![0; 16];

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -4,6 +4,10 @@
 //! option. This file may not be copied, modified, or distributed
 //! except according to those terms.
 
+mod multi_product;
+#[cfg(feature = "use_std")]
+pub use self::multi_product::*;
+
 use std::fmt;
 use std::mem::replace;
 use std::iter::{Fuse, Peekable, FromIterator};

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -1,0 +1,219 @@
+#![cfg(feature = "use_std")]
+
+use size_hint;
+use Itertools;
+
+#[derive(Clone)]
+/// An iterator adaptor that iterates over the cartesian product of
+/// multiple iterators of type `I`.
+///
+/// An iterator element type is `Vec<I>`.
+///
+/// See [`.multi_cartesian_product()`](../trait.Itertools.html#method.multi_cartesian_product)
+/// for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct MultiProduct<I>(Vec<MultiProductIter<I>>)
+    where I: Iterator + Clone,
+          I::Item: Clone;
+
+/// Create a new cartesian product iterator over an arbitrary number
+/// of iterators of the same type.
+///
+/// Iterator element is of type `Vec<H::Item::Item>`.
+pub fn multi_cartesian_product<H>(iters: H) -> MultiProduct<<H::Item as IntoIterator>::IntoIter>
+    where H: Iterator,
+          H::Item: IntoIterator,
+          <H::Item as IntoIterator>::IntoIter: Clone,
+          <H::Item as IntoIterator>::Item: Clone
+{
+    MultiProduct(iters.map(|i| MultiProductIter::new(i.into_iter())).collect())
+}
+
+#[derive(Clone)]
+/// Holds the state of a single iterator within a MultiProduct.
+struct MultiProductIter<I>
+    where I: Iterator + Clone,
+          I::Item: Clone
+{
+    cur: Option<I::Item>,
+    iter: I,
+    iter_orig: I,
+}
+
+/// Holds the current state during an iteration of a MultiProduct.
+enum MultiProductIterState {
+    StartOfIter,
+    MidIter { on_first_iter: bool },
+}
+
+impl<I> MultiProduct<I>
+    where I: Iterator + Clone,
+          I::Item: Clone
+{
+    /// Iterates the rightmost iterator, then recursively iterates iterators
+    /// to the left if necessary.
+    ///
+    /// Returns true if the iteration succeeded, else false.
+    fn iterate_last(
+        multi_iters: &mut [MultiProductIter<I>],
+        mut state: MultiProductIterState
+    ) -> bool {
+        use self::MultiProductIterState::*;
+
+        if let Some((last, rest)) = multi_iters.split_last_mut() {
+            let on_first_iter = match state {
+                StartOfIter => {
+                    let on_first_iter = !last.in_progress();
+                    state = MidIter { on_first_iter: on_first_iter };
+                    on_first_iter
+                },
+                MidIter { on_first_iter } => on_first_iter
+            };
+
+            if !on_first_iter {
+                last.iterate();
+            }
+
+            if last.in_progress() {
+                true
+            } else if MultiProduct::iterate_last(rest, state) {
+                last.reset();
+                last.iterate();
+                // If iterator is None twice consecutively, then iterator is
+                // empty; whole product is empty.
+                last.in_progress()
+            } else {
+                false
+            }
+        } else {
+            // Reached end of iterator list. On initialisation, return true.
+            // At end of iteration (final iterator finishes), finish.
+            match state {
+                StartOfIter => false,
+                MidIter { on_first_iter } => on_first_iter
+            }
+        }
+    }
+
+    /// Returns the unwrapped value of the next iteration.
+    fn curr_iterator(&self) -> Vec<I::Item> {
+        self.0.iter().map(|multi_iter| {
+            multi_iter.cur.clone().unwrap()
+        }).collect()
+    }
+
+    /// Returns true if iteration has started and has not yet finished; false
+    /// otherwise.
+    fn in_progress(&self) -> bool {
+        if let Some(last) = self.0.last() {
+            last.in_progress()
+        } else {
+            false
+        }
+    }
+}
+
+impl<I> MultiProductIter<I>
+    where I: Iterator + Clone,
+          I::Item: Clone
+{
+    fn new(iter: I) -> Self {
+        MultiProductIter {
+            cur: None,
+            iter: iter.clone(),
+            iter_orig: iter
+        }
+    }
+
+    /// Iterate the managed iterator.
+    fn iterate(&mut self) {
+        self.cur = self.iter.next();
+    }
+
+    /// Reset the managed iterator.
+    fn reset(&mut self) {
+        self.iter = self.iter_orig.clone();
+    }
+
+    /// Returns true if the current iterator has been started and has not yet
+    /// finished; false otherwise.
+    fn in_progress(&self) -> bool {
+        self.cur.is_some()
+    }
+}
+
+impl<I> Iterator for MultiProduct<I>
+    where I: Iterator + Clone,
+          I::Item: Clone
+{
+    type Item = Vec<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if MultiProduct::iterate_last(
+            &mut self.0,
+            MultiProductIterState::StartOfIter
+        ) {
+            Some(self.curr_iterator())
+        } else {
+            None
+        }
+    }
+
+    fn count(self) -> usize {
+        if self.0.len() == 0 {
+            return 0;
+        }
+
+        if !self.in_progress() {
+            return self.0.into_iter().fold(1, |acc, multi_iter| {
+                acc * multi_iter.iter.count()
+            });
+        }
+
+        self.0.into_iter().fold(
+            0,
+            |acc, MultiProductIter { iter, iter_orig, cur: _ }| {
+                let total_count = iter_orig.count();
+                let cur_count = iter.count();
+                acc * total_count + cur_count
+            }
+        )
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Not ExactSizeIterator because size may be larger than usize
+        if self.0.len() == 0 {
+            return (0, Some(0));
+        }
+
+        if !self.in_progress() {
+            return self.0.iter().fold((1, Some(1)), |acc, multi_iter| {
+                size_hint::mul(acc, multi_iter.iter.size_hint())
+            });
+        }
+
+        self.0.iter().fold(
+            (0, Some(0)),
+            |acc, &MultiProductIter { ref iter, ref iter_orig, cur: _ }| {
+                let cur_size = iter.size_hint();
+                let total_size = iter_orig.size_hint();
+                size_hint::add(size_hint::mul(acc, total_size), cur_size)
+            }
+        )
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        let iter_count = self.0.len();
+
+        let lasts: Self::Item = self.0.into_iter()
+            .map(|multi_iter| multi_iter.iter.last())
+            .while_some()
+            .collect();
+
+        if lasts.len() == iter_count {
+            Some(lasts)
+        } else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@ pub mod structs {
         Update,
     };
     #[cfg(feature = "use_std")]
+    pub use adaptors::MultiProduct;
+    #[cfg(feature = "use_std")]
     pub use combinations::Combinations;
     pub use cons_tuples_impl::ConsTuples;
     pub use format::{Format, FormatWith};
@@ -789,6 +791,40 @@ pub trait Itertools : Iterator {
               J::IntoIter: Clone
     {
         adaptors::cartesian_product(self, other.into_iter())
+    }
+
+    /// Return an iterator adaptor that iterates over the cartesian product of
+    /// all sub-iterators returned by meta-iterator `self`.
+    ///
+    /// All provided iterators must yield the same `Item` type. To generate
+    /// the product of iterators yielding multiple types, use the
+    /// [`iproduct`](macro.iproduct.html) macro.
+    ///
+    ///
+    /// An iterator element type is `Vec<I>`.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    /// let mut multi_prod = (0..3).map(|i| (i * 2)..(i * 2 + 2))
+    ///     .multi_cartesian_product();
+    /// assert_eq!(multi_prod.next(), Some(vec![0, 2, 4]));
+    /// assert_eq!(multi_prod.next(), Some(vec![0, 2, 5]));
+    /// assert_eq!(multi_prod.next(), Some(vec![0, 3, 4]));
+    /// assert_eq!(multi_prod.next(), Some(vec![0, 3, 5]));
+    /// assert_eq!(multi_prod.next(), Some(vec![1, 2, 4]));
+    /// assert_eq!(multi_prod.next(), Some(vec![1, 2, 5]));
+    /// assert_eq!(multi_prod.next(), Some(vec![1, 3, 4]));
+    /// assert_eq!(multi_prod.next(), Some(vec![1, 3, 5]));
+    /// assert_eq!(multi_prod.next(), None);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn multi_cartesian_product(self) -> MultiProduct<<Self::Item as IntoIterator>::IntoIter>
+        where Self: Iterator + Sized,
+              Self::Item: IntoIterator,
+              <Self::Item as IntoIterator>::IntoIter: Clone,
+              <Self::Item as IntoIterator>::Item: Clone
+    {
+        adaptors::multi_cartesian_product(self)
     }
 
     /// Return an iterator adaptor that uses the passed-in closure to

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -27,7 +27,6 @@ fn product3() {
     }
 }
 
-
 #[test]
 fn interleave_shortest() {
     let v0: Vec<i32> = vec![0, 2, 4];


### PR DESCRIPTION
Hello!

I have created a new Itertools adaptor: `MultiProduct`. It is to be used on a meta-iterator (iterator which yield iterators) to produce the cartesian product of the iterators it yields. It is created by calling the `.multi_cartesian_product()` method.

This can be used, instead of the `iproduct` macro, when the number of iterators is not known at compile time.

It currently uses a recursive function, which makes it susceptible to stack overflows for products with a huge number of elements. I could probably rework this to use a heap stack if desired, although I haven't thought about it too much so far.

It adds 7 new top-level items to `adaptors/mod.rs`, so maybe it'd be worth splitting into its own file?

Any comments/questions, please let me know.