### PR TITLE
Add multizip_fallback method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub mod structs {
     pub use zip_eq_impl::ZipEq;
     pub use zip_longest::ZipLongest;
     pub use ziptuple::Zip;
+    pub use ziptuplefallback::ZipAll;
 }
 pub use structs::*;
 pub use concat_impl::concat;
@@ -112,6 +113,7 @@ pub use repeatn::repeat_n;
 pub use sources::{repeat_call, unfold, iterate};
 pub use with_position::Position;
 pub use ziptuple::multizip;
+pub use ziptuplefallback::multizip_fallback;
 mod adaptors;
 mod either_or_both;
 pub use either_or_both::EitherOrBoth;
@@ -153,6 +155,7 @@ mod with_position;
 mod zip_eq_impl;
 mod zip_longest;
 mod ziptuple;
+mod ziptuplefallback;
 
 #[macro_export]
 /// Create an iterator over the “cartesian product” of iterators.

--- a/src/ziptuplefallback.rs
+++ b/src/ziptuplefallback.rs
@@ -1,0 +1,119 @@
+use super::size_hint;
+
+/// See [`multizip_fallback`](../fn.multizip_fallback.html) for more information.
+#[derive(Clone)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct ZipAll<T, X> {
+    t: T,
+    def: X
+}
+/// An iterator that allows running multiple iterators in lockstep while extending depleted
+/// iterators with fallback values.
+///
+/// The iterator `ZipAll<(A, C, ..., M), (B, D, ..., N)>` is formed from a tuple of tuples where
+/// the inner tuples contains an Iterator (or values that implement `IntoIterator`) and a fallback
+/// value. The iterator yields elements until all of the subiterators returns None. If any 
+/// subiterator returns None before they all do, its fallback value will be used.
+///
+/// The iterator element type is a tuple like `(B, D, ..., N)` where `B` to `N` are the
+/// element types of the subiterator.
+///
+/// If extending with fallback values isn't needed, use [`multizip()`].
+///
+/// [`multizip()`]: fn.multizip.html
+///
+/// ```
+/// use itertools::multizip_fallback;
+///
+/// let a = &[2, 8, 5, 7];
+/// let b = 5..7;
+/// let c = vec![10, 2, 20];
+/// let mut multiples = Vec::new();
+///
+/// for (first, second, third) in multizip_fallback(((a, &3), (b, 2), (c, 1))) {
+///     multiples.push(*first * second * third);
+/// }
+///
+/// assert_eq!(multiples, vec![2*5*10, 8*6*2, 5*2*20, 7*2*1]);
+/// ```
+pub fn multizip_fallback<T, U, X>(t: U) -> ZipAll<T, X>
+    where ZipAll<T, X>: From<U>,
+          ZipAll<T, X>: Iterator,
+{
+    ZipAll::from(t)
+}
+
+macro_rules! impl_zip_all_iter {
+    ($(($B:ident, $C:ident)),*) => (
+        #[allow(non_snake_case)]
+        impl<$($B: IntoIterator<Item = $C>),*, $($C: Clone),*> From<($(($B,$C),)*)> for ZipAll<($($B::IntoIter,)*), ($($C,)*)> {
+            fn from(t: ($(($B,$C),)*)) -> Self {
+                let ($(($B,$C),)*)= t;
+                ZipAll {
+                    t: ($($B.into_iter(),)*),
+                    def: ($($C,)*)
+                }
+            }
+        }
+
+        #[allow(non_snake_case)]
+        #[allow(unused_assignments)]
+        impl<$($B,$C),*> Iterator for ZipAll<($($B,)*), ($($C,)*)>
+            where
+            $(
+                $B: Iterator<Item = $C>,
+                $C: Clone,
+            )*
+        {
+            type Item = ($($B::Item,)*);
+
+            fn next(&mut self) -> Option<Self::Item>
+            {
+                let ($(ref mut $B,)*) = self.t;
+                let ($(ref mut $C,)*) = self.def;
+                let mut empty = true;
+                $(
+                    let $B = match $B.next() {
+                        None => $C.clone(),
+                        Some(elt) => {
+                            empty = false;
+                            elt
+                        }
+                    };
+                )*
+                if empty {
+                    None
+                } else {
+                    Some(($($B,)*))
+                }
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>)
+            {
+                let sh = (::std::usize::MAX, None);
+                let ($(ref $B,)*) = self.t;
+                $(
+                    let sh = size_hint::min($B.size_hint(), sh);
+                )*
+                sh
+            }
+        }
+        #[allow(non_snake_case)]
+        impl<$($B,$C),*> ExactSizeIterator for ZipAll<($($B,)*), ($($C,)*)>
+        where
+        $(
+            $B: ExactSizeIterator<Item = $C>,
+            $C: Clone,
+        )*
+        { }
+    );
+}
+
+impl_zip_all_iter!((A, B));
+impl_zip_all_iter!((A, B), (C, D));
+impl_zip_all_iter!((A, B), (C, D), (E, F));
+impl_zip_all_iter!((A, B), (C, D), (E, F), (G, H));
+impl_zip_all_iter!((A, B), (C, D), (E, F), (G, H), (I, J));
+impl_zip_all_iter!((A, B), (C, D), (E, F), (G, H), (I, J), (K, L));
+impl_zip_all_iter!((A, B), (C, D), (E, F), (G, H), (I, J), (K, L), (M, N));
+impl_zip_all_iter!((A, B), (C, D), (E, F), (G, H), (I, J), (K, L), (M, N), (O, P));

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -10,6 +10,7 @@
 use it::Itertools;
 use it::interleave;
 use it::multizip;
+use it::multizip_fallback;
 use it::free::put_back;
 
 #[test]
@@ -68,6 +69,24 @@ fn izip3() {
     for (_, _, _, _, _) in multizip((0..3, 0..2, xs.iter(), &xs, xs.to_vec())) {
         /* test compiles */
     }
+}
+
+#[test]
+fn izip_fallback() {
+    let mut zip = multizip_fallback(((0..3, 11), (0..2, 12), (0..2i8, 13)));
+    for i in 0..2 {
+        assert!((i as usize, i, i as i8) == zip.next().unwrap());
+    }
+    assert!((2, 12, 13) == zip.next().unwrap());
+
+    let xs: [isize; 0] = [];
+    let mut zip = multizip_fallback(((0..3, 11), (0..2, 12), (0..2i8, 13), (xs.iter(), &14)));
+    assert!((0, 0, 0, &14) == zip.next().unwrap());
+
+    let st: [&str; 1] = ["te"];
+    let mut zip = multizip_fallback(((0..1, 11), (0..1, 12), (0..1, 13), (st.iter(), &"ing")));
+    assert!((0, 0, 0, &"te") == zip.next().unwrap());
+    assert!(zip.next().is_none());
 }
 
 #[test]


### PR DESCRIPTION
Implements #242 as a new function called `multizip_fallback` which takes a tuple of tuples as an argument where the inner tuples are the subiterators and their respective fallback values.
Most of the code is the same as for `multizip` so nothing too weird going on.

Example usage:
```rust
use itertools::multizip_fallback;
fn main {
    let a = &[2, 8, 5, 7];
    let b = 5..7;
    let c = vec![10, 2, 20];
    let mut multiples = Vec::new();
    for (first, second, third) in multizip_fallback(((a, &3), (b, 2), (c, 1))) {
        multiples.push(*first * second * third);
    }
    assert_eq!(multiples, vec![2*5*10, 8*6*2, 5*2*20, 7*2*1]);
}
```