### PR TITLE
Implement PeekingNext for MultiPeek

### DIFF
--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -3,6 +3,7 @@
 use std::iter::Fuse;
 use std::collections::VecDeque;
 use size_hint;
+use PeekingNext;
 
 /// See [`multipeek()`](../fn.multipeek.html) for more information.
 #[derive(Clone, Debug)]
@@ -54,6 +55,25 @@ impl<I: Iterator> MultiPeek<I> {
 
         self.index += 1;
         ret
+    }
+}
+
+impl<I> PeekingNext for MultiPeek<I>
+    where I: Iterator,
+{
+    fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
+        where F: FnOnce(&Self::Item) -> bool
+    {
+        if self.buf.is_empty() {
+            if let Some(r) = self.peek() {
+                if !accept(r) { return None }
+            }
+        } else {
+            if let Some(r) = self.buf.get(0) {
+                if !accept(r) { return None }
+            }
+        }
+        self.next()
     }
 }
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -231,7 +231,7 @@ fn kmerge() {
 #[test]
 fn kmerge_2() {
     let its = vec![3, 2, 1, 0].into_iter().map(|s| (s..10).step(4));
-    
+
     it::assert_equal(its.kmerge(), (0..10));
 }
 
@@ -294,6 +294,8 @@ fn test_multipeek() {
     assert_eq!(mp.peek(), None);
     assert_eq!(mp.next(), Some(3));
     assert_eq!(mp.next(), Some(4));
+    assert_eq!(mp.peek(), Some(&5));
+    assert_eq!(mp.peek(), None);
     assert_eq!(mp.next(), Some(5));
     assert_eq!(mp.next(), None);
     assert_eq!(mp.peek(), None);
@@ -312,6 +314,32 @@ fn test_multipeek_reset() {
     mp.reset_peek();
     assert_eq!(mp.peek(), Some(&2));
     assert_eq!(mp.next(), Some(2));
+}
+
+#[test]
+fn test_multipeek_peeking_next() {
+    use it::PeekingNext;
+    let nums = vec![1u8,2,3,4,5,6,7];
+
+    let mut mp = multipeek(nums.iter().map(|&x| x));
+    assert_eq!(mp.peeking_next(|&x| x != 0), Some(1));
+    assert_eq!(mp.next(), Some(2));
+    assert_eq!(mp.peek(), Some(&3));
+    assert_eq!(mp.peek(), Some(&4));
+    assert_eq!(mp.peeking_next(|&x| x == 3), Some(3));
+    assert_eq!(mp.peek(), Some(&4));
+    assert_eq!(mp.peeking_next(|&x| x != 4), None);
+    assert_eq!(mp.peeking_next(|&x| x == 4), Some(4));
+    assert_eq!(mp.peek(), Some(&5));
+    assert_eq!(mp.peek(), Some(&6));
+    assert_eq!(mp.peeking_next(|&x| x != 5), None);
+    assert_eq!(mp.peek(), Some(&7));
+    assert_eq!(mp.peeking_next(|&x| x == 5), Some(5));
+    assert_eq!(mp.peeking_next(|&x| x == 6), Some(6));
+    assert_eq!(mp.peek(), Some(&7));
+    assert_eq!(mp.peek(), None);
+    assert_eq!(mp.next(), Some(7));
+    assert_eq!(mp.peek(), None);
 }
 
 #[test]


### PR DESCRIPTION
I am writing a parser and I recently changed the main iterator from the standard `Peekable` into a `MultiPeek`.

I was surprised I couldn't use it with `peeking_take_while`: I expected that `MutliPeek` -- being an "upgrade" over `Peekable` -- would work just as fine.

The change is very simple. I wrote the `impl` in `mutlipeek_impl.rs` because I use internals of `MultiPeek` to always check for the "true" next value that `iter.next()` will yield.

I added two assertions in the `mutlipeek` test. If this is unwelcome, I'll happily submit a new pull request without those.