### PR TITLE
Return an iterator from sorted/sorted_by/sorted_by_key

### DIFF
--- a/src/free.rs
+++ b/src/free.rs
@@ -7,6 +7,9 @@
 use std::fmt::Display;
 use std::iter::{self, Zip};
 #[cfg(feature = "use_std")]
+type VecIntoIter<T> = ::std::vec::IntoIter<T>;
+
+#[cfg(feature = "use_std")]
 use Itertools;
 
 pub use adaptors::{
@@ -211,9 +214,11 @@ pub fn join<I>(iterable: I, sep: &str) -> String
     iterable.into_iter().join(sep)
 }
 
-/// Collect all the iterable's elements into a sorted vector in ascending order.
+/// Sort all iterator elements into a new iterator in ascending order.
 ///
-/// `IntoIterator` enabled version of `iterable.sorted()`.
+/// `IntoIterator` enabled version of [`iterable.sorted()`][1].
+///
+/// [1]: trait.Itertools.html#method.sorted
 ///
 /// ```
 /// use itertools::sorted;
@@ -222,7 +227,7 @@ pub fn join<I>(iterable: I, sep: &str) -> String
 /// assert_equal(sorted("rust".chars()), "rstu".chars());
 /// ```
 #[cfg(feature = "use_std")]
-pub fn sorted<I>(iterable: I) -> Vec<I::Item>
+pub fn sorted<I>(iterable: I) -> VecIntoIter<I::Item>
     where I: IntoIterator,
           I::Item: Ord
 {

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -269,19 +269,19 @@ fn sorted_by() {
     let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| {
         a.cmp(&b)
     });
-    assert_eq!(sc, vec![1, 2, 3, 4]);
+    it::assert_equal(sc, vec![1, 2, 3, 4]);
 
     let v = (0..5).sorted_by(|&a, &b| a.cmp(&b).reverse());
-    assert_eq!(v, vec![4, 3, 2, 1, 0]);
+    it::assert_equal(v, vec![4, 3, 2, 1, 0]);
 }
 
 #[test]
 fn sorted_by_key() {
     let sc = [3, 4, 1, 2].iter().cloned().sorted_by_key(|&x| x);
-    assert_eq!(sc, vec![1, 2, 3, 4]);
+    it::assert_equal(sc, vec![1, 2, 3, 4]);
 
     let v = (0..5).sorted_by_key(|&x| -x);
-    assert_eq!(v, vec![4, 3, 2, 1, 0]);
+    it::assert_equal(v, vec![4, 3, 2, 1, 0]);
 }
 
 #[test]


### PR DESCRIPTION
Prefer returning an iterator for much more fluent use of this method.

A FromIterator special case in `Vec` means that the `std::vec::IntoIter` can be converted into a `Vec` with no cost, so for the case where a Vec is needed, we incur no cost except for the extra typing.

Fixes #238 