### PR TITLE
Add Itertools::replace adaptor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub mod structs {
     #[cfg(feature = "use_std")]
     pub use rciter_impl::RcIter;
     pub use repeatn::RepeatN;
+    pub use replace::Replace;
     pub use sources::{RepeatCall, Unfold, Iterate};
     #[cfg(feature = "use_std")]
     pub use tee::Tee;
@@ -144,6 +145,7 @@ mod put_back_n_impl;
 #[cfg(feature = "use_std")]
 mod rciter_impl;
 mod repeatn;
+mod replace;
 mod size_hint;
 mod sources;
 #[cfg(feature = "use_std")]
@@ -332,6 +334,29 @@ pub trait Itertools : Iterator {
               Self::Item: Clone
     {
         intersperse::intersperse(self, element)
+    }
+
+    /// An iterator adaptor that replaces items that equal `needle` with other
+    /// items.
+    ///
+    /// For every occurrence of `needle`, the contents of the `with` iterator are yielded.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// itertools::assert_equal(
+    ///     [0, 1, 2, 1, 3].iter().replace(&1, &[-4, -3]).collect_vec(),
+    ///     &[0, -4, -3, 2, -4, -3, 3]
+    /// );
+    /// ```
+    fn replace<R>(self, needle: Self::Item, with: R) -> Replace<Self::Item, Self, R::IntoIter>
+        where
+            Self::Item: Eq,
+            R: IntoIterator<Item=Self::Item>,
+            R::IntoIter: Clone,
+            Self: Sized,
+    {
+        replace::replace(self, needle, with.into_iter())
     }
 
     /// Create an iterator which iterates over both this and the specified

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,26 +336,26 @@ pub trait Itertools : Iterator {
         intersperse::intersperse(self, element)
     }
 
-    /// An iterator adaptor that replaces items that equal `needle` with other
+    /// An iterator adaptor that replaces items that satisfy a predicate with other
     /// items.
     ///
-    /// For every occurrence of `needle`, the contents of the `with` iterator are yielded.
+    /// For every item satisfying `cond`, the contents of the `with` iterator are yielded.
     ///
     /// ```
     /// use itertools::Itertools;
     ///
     /// itertools::assert_equal(
-    ///     [0, 1, 2, 1, 3].iter().replace(&1, &[-4, -3]).collect_vec(),
+    ///     [0, 1, 2, 1, 3].iter().replace(|&&i| i == 1, &[-4, -3]).collect_vec(),
     ///     &[0, -4, -3, 2, -4, -3, 3]
     /// );
     /// ```
-    fn replace<R>(self, needle: Self::Item, with: R) -> Replace<Self::Item, Self, R::IntoIter>
-        where Self::Item: Eq,
+    fn replace<C, R>(self, cond: C, with: R) -> Replace<C, Self, R::IntoIter>
+        where C: FnMut(&Self::Item) -> bool,
               R: IntoIterator<Item=Self::Item>,
               R::IntoIter: Clone,
-              Self: Sized,
+              Self: Sized
     {
-        replace::replace(self, needle, with.into_iter())
+        replace::replace(self, cond, with.into_iter())
     }
 
     /// Create an iterator which iterates over both this and the specified

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,11 +350,10 @@ pub trait Itertools : Iterator {
     /// );
     /// ```
     fn replace<R>(self, needle: Self::Item, with: R) -> Replace<Self::Item, Self, R::IntoIter>
-        where
-            Self::Item: Eq,
-            R: IntoIterator<Item=Self::Item>,
-            R::IntoIter: Clone,
-            Self: Sized,
+        where Self::Item: Eq,
+              R: IntoIterator<Item=Self::Item>,
+              R::IntoIter: Clone,
+              Self: Sized,
     {
         replace::replace(self, needle, with.into_iter())
     }

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1,0 +1,62 @@
+pub fn replace<T, I, R>(iter: I, needle: T, replacement: R) -> Replace<T, I, R>
+    where
+        T: Eq,
+        I: Iterator<Item=T>,
+        R: Iterator<Item=T> + Clone,
+{
+    Replace { needle, iter, with_orig: replacement, with: None }
+}
+
+/// An iterator adaptor that replaces occurrences of an item with a different sequence of items.
+///
+/// It is returned by [`Itertools::replace`].
+///
+/// [`Itertools::replace`]: ../trait.Itertools.html#method.replace
+pub struct Replace<T, I, R>
+    where
+        T: Eq,
+        I: Iterator<Item=T>,
+        R: Iterator<Item=T> + Clone
+{
+    needle: I::Item,
+    iter: I,
+    with: Option<R>,
+    with_orig: R,
+}
+
+impl<T, I, R> Iterator for Replace<T, I, R>
+    where
+        T: Eq,
+        I: Iterator<Item=T>,
+        R: Iterator<Item=T> + Clone,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<I::Item> {
+        loop {
+            self.with = match self.with {
+                Some(ref mut replacement) => {
+                    match replacement.next() {
+                        Some(item) => {
+                            // emit replacement item
+                            return Some(item);
+                        }
+                        None => {
+                            // continue with original iterator
+                            None
+                        }
+                    }
+                }
+                None => {
+                    let item = self.iter.next()?;
+                    if item == self.needle {
+                        // emit the replacement iterator once
+                        Some(self.with_orig.clone())
+                    } else {
+                        return Some(item);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1,8 +1,7 @@
 pub fn replace<T, I, R>(iter: I, needle: T, replacement: R) -> Replace<T, I, R>
-    where
-        T: Eq,
-        I: Iterator<Item=T>,
-        R: Iterator<Item=T> + Clone,
+    where T: Eq,
+          I: Iterator<Item=T>,
+          R: Iterator<Item=T> + Clone,
 {
     Replace { needle: needle, iter: iter, with_orig: replacement, with: None }
 }
@@ -13,10 +12,9 @@ pub fn replace<T, I, R>(iter: I, needle: T, replacement: R) -> Replace<T, I, R>
 ///
 /// [`Itertools::replace`]: ../trait.Itertools.html#method.replace
 pub struct Replace<T, I, R>
-    where
-        T: Eq,
-        I: Iterator<Item=T>,
-        R: Iterator<Item=T> + Clone
+    where T: Eq,
+          I: Iterator<Item=T>,
+          R: Iterator<Item=T> + Clone
 {
     needle: I::Item,
     iter: I,
@@ -25,10 +23,9 @@ pub struct Replace<T, I, R>
 }
 
 impl<T, I, R> Iterator for Replace<T, I, R>
-    where
-        T: Eq,
-        I: Iterator<Item=T>,
-        R: Iterator<Item=T> + Clone,
+    where T: Eq,
+          I: Iterator<Item=T>,
+          R: Iterator<Item=T> + Clone,
 {
     type Item = I::Item;
 

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -4,7 +4,7 @@ pub fn replace<T, I, R>(iter: I, needle: T, replacement: R) -> Replace<T, I, R>
         I: Iterator<Item=T>,
         R: Iterator<Item=T> + Clone,
 {
-    Replace { needle, iter, with_orig: replacement, with: None }
+    Replace { needle: needle, iter: iter, with_orig: replacement, with: None }
 }
 
 /// An iterator adaptor that replaces occurrences of an item with a different sequence of items.
@@ -48,12 +48,14 @@ impl<T, I, R> Iterator for Replace<T, I, R>
                     }
                 }
                 None => {
-                    let item = self.iter.next()?;
-                    if item == self.needle {
-                        // emit the replacement iterator once
-                        Some(self.with_orig.clone())
-                    } else {
-                        return Some(item);
+                    match self.iter.next() {
+                        None => return None,
+                        Some(item) => if item == self.needle {
+                            // emit the replacement iterator once
+                            Some(self.with_orig.clone())
+                        } else {
+                            return Some(item);
+                        }
                     }
                 }
             }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -722,15 +722,15 @@ fn fold_while() {
 
 #[test]
 fn replace() {
-    it::assert_equal((0..4).replace(2, vec![2, 2]), vec![0, 1, 2, 2, 3]);
+    it::assert_equal((0..4).replace(|&i| i == 2, vec![2, 2]), vec![0, 1, 2, 2, 3]);
 
-    it::assert_equal(vec![0, 1, 2, 2].into_iter().replace(2, vec![]), (0..2));
-    it::assert_equal(vec![2, 2, 0, 1, 2, 2].into_iter().replace(2, vec![]), (0..2));
+    it::assert_equal(vec![0, 1, 2, 2].into_iter().replace(|&i| i == 2, vec![]), (0..2));
+    it::assert_equal(vec![2, 2, 0, 1, 2, 2].into_iter().replace(|&i| i == 2, vec![]), (0..2));
 
     // and now, for my final trick, I will make this iterator *disappear*!
     it::assert_equal((0..3)
-                         .replace(0, vec![])
-                         .replace(1, vec![])
-                         .replace(2, vec![]),
+                         .replace(|&i| i == 0, vec![])
+                         .replace(|&i| i == 1, vec![])
+                         .replace(|&i| i == 2, vec![]),
                      vec![]);
 }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -720,3 +720,17 @@ fn fold_while() {
     assert_eq!(sum, 15);
 }
 
+#[test]
+fn replace() {
+    it::assert_equal((0..4).replace(2, vec![2, 2]), vec![0, 1, 2, 2, 3]);
+
+    it::assert_equal(vec![0, 1, 2, 2].into_iter().replace(2, vec![]), (0..2));
+    it::assert_equal(vec![2, 2, 0, 1, 2, 2].into_iter().replace(2, vec![]), (0..2));
+
+    // and now, for my final trick, I will make this iterator *disappear*!
+    it::assert_equal((0..3)
+                         .replace(0, vec![])
+                         .replace(1, vec![])
+                         .replace(2, vec![]),
+                     vec![]);
+}


### PR DESCRIPTION
Allows replacing items from an iterator with the contents of another iterator.

This works similar to `str::replace`, but for arbitrary (clonable) types and on iterators, needing no allocation.