### PR TITLE
Add Itertools::to_lookup

### DIFF
--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,0 +1,26 @@
+#![cfg(feature = "use_std")]
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::iter::Iterator;
+
+/// Return a `HashMap` of keys mapped to a list of their corresponding values,
+/// as determined by the specified function.
+///
+/// See [`.to_lookup()`](../trait.Itertools.html#method.to_lookup)
+/// for more information.
+pub fn to_lookup<I, K, F>(iter: I, get_key: F) -> HashMap<K, Vec<I::Item>>
+    where I: Iterator,
+          K: Hash + Eq,
+          F: Fn(&I::Item) -> K
+{
+    let mut lookup = HashMap::new();
+
+    for val in iter {
+        let key = get_key(&val);
+        let slot = lookup.entry(key).or_insert(Vec::new());
+        slot.push(val);
+    }
+
+    lookup
+}

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -841,6 +841,20 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn correct_lookup_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
+        let count = a.len();
+        let lookup = a.into_iter().to_lookup(|&i| i % modulo);
+
+        assert_eq!(lookup.values().flat_map(|vals| vals.iter()).count(), count);
+
+        for (&key, vals) in lookup.iter() {
+            assert!(vals.iter().all(|&val| val % modulo == key));
+        }
+    }
+}
+
+quickcheck! {
     fn equal_tuple_windows_1(a: Vec<u8>) -> bool {
         let x = a.windows(1).map(|s| (&s[0], ));
         let y = a.iter().tuple_windows::<(_,)>();


### PR DESCRIPTION
Fulfills #92.

Create a Lookup from an Iterator, in a similar manner to [C#'s ToLookup](https://msdn.microsoft.com/en-us/library/bb549073(v=vs.110).aspx).

Returns a plain `HashMap`, so no special `FromIterator` or `.iter()` implementations. My only concern is, if we do want to specialise this in future, it will require a new type and be a breaking change.