### PR TITLE
Attempt to fix travis tests for Rust 1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ sudo: false
 matrix:
   include:
     - rust: 1.12.0
+      before_script:
+        # rand 0.4.2 requires rust 1.15, and rand-0.3.22 requires rand-0.4  :/
+        # manually hacking the lockfile due to the limitations of cargo#2773
+        - cargo generate-lockfile
+        - sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
+        - sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+    - rust: 1.15.0
     - rust: stable
     - rust: beta
     - rust: nightly


### PR DESCRIPTION
A fix that I copied from cuviper (Josh Stone) in the rayon project.

This resolves our testing & release deadlock with a workaround. Lovingly copy-pasted from @cuviper's work in rayon.