### PR TITLE
Add some Debug implementations

### DIFF
--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -29,7 +29,7 @@ pub fn multi_cartesian_product<H>(iters: H) -> MultiProduct<<H::Item as IntoIter
     MultiProduct(iters.map(|i| MultiProductIter::new(i.into_iter())).collect())
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// Holds the state of a single iterator within a MultiProduct.
 struct MultiProductIter<I>
     where I: Iterator + Clone,
@@ -41,6 +41,7 @@ struct MultiProductIter<I>
 }
 
 /// Holds the current state during an iteration of a MultiProduct.
+#[derive(Debug)]
 enum MultiProductIterState {
     StartOfIter,
     MidIter { on_first_iter: bool },

--- a/src/cons_tuples_impl.rs
+++ b/src/cons_tuples_impl.rs
@@ -42,6 +42,7 @@ impl_cons_iter!(A, B, C, D, E, F, G, H,);
 ///
 /// Used by the `iproduct!()` macro.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug)]
 pub struct ConsTuples<I, J>
     where I: Iterator<Item=J>,
 {

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -19,6 +19,7 @@ impl<'a, A, K, F: ?Sized> KeyFunction<A> for F
 
 
 /// ChunkIndex acts like the grouping key function for IntoChunks
+#[derive(Debug)]
 struct ChunkIndex {
     size: usize,
     index: usize,

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -11,6 +11,7 @@ use super::size_hint;
 ///
 /// See [`.intersperse()`](../trait.Itertools.html#method.intersperse) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug)]
 pub struct Intersperse<I>
     where I: Iterator
 {

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -3,6 +3,7 @@ use size_hint;
 use Itertools;
 
 use std::mem::replace;
+use std::fmt;
 
 macro_rules! clone_fields {
     ($name:ident, $base:expr, $($field:ident),+) => (
@@ -115,6 +116,13 @@ pub struct KMerge<I>
     where I: Iterator
 {
     heap: Vec<HeadTail<I>>,
+}
+
+impl<I> fmt::Debug for KMerge<I>
+    where I: Iterator + fmt::Debug,
+          I::Item: fmt::Debug,
+{
+    debug_fmt_fields!(KMerge, heap);
 }
 
 /// Create an iterator that merges elements of the contained iterators using

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -21,6 +21,7 @@ macro_rules! clone_fields {
 ///
 /// The meanings of `PartialOrd` and `Ord` are reversed so as to turn the heap used in
 /// `KMerge` into a min-heap.
+#[derive(Debug)]
 struct HeadTail<I>
     where I: Iterator
 {

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -201,6 +201,13 @@ pub struct KMergeBy<I, F>
     less_than: F,
 }
 
+impl<I, F> fmt::Debug for KMergeBy<I, F>
+    where I: Iterator + fmt::Debug,
+          I::Item: fmt::Debug,
+{
+    debug_fmt_fields!(KMergeBy, heap);
+}
+
 /// Create an iterator that merges elements of the contained iterators.
 ///
 /// Equivalent to `iterable.into_iter().kmerge_by(less_than)`.

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::iter::Fuse;
+use std::fmt;
 
 use super::adaptors::{PutBack, put_back};
 use either_or_both::EitherOrBoth;
@@ -28,6 +29,15 @@ pub struct MergeJoinBy<I: Iterator, J: Iterator, F> {
     left: PutBack<Fuse<I>>,
     right: PutBack<Fuse<J>>,
     cmp_fn: F
+}
+
+impl<I, J, F> fmt::Debug for MergeJoinBy<I, J, F>
+    where I: Iterator + fmt::Debug,
+          I::Item: fmt::Debug,
+          J: Iterator + fmt::Debug,
+          J::Item: fmt::Debug,
+{
+    debug_fmt_fields!(MergeJoinBy, left, right);
 }
 
 impl<I, J, F> Iterator for MergeJoinBy<I, J, F>

--- a/src/process_results_impl.rs
+++ b/src/process_results_impl.rs
@@ -5,6 +5,7 @@
 /// Used by [`process_results`](../fn.process_results.html), see its docs
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug)]
 pub struct ProcessResults<'a, I, E: 'a> {
     error: &'a mut Result<(), E>,
     iter: I,

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 /// A wrapper for `Rc<RefCell<I>>`, that implements the `Iterator` trait.
+#[derive(Debug)]
 pub struct RcIter<I> {
     /// The boxed iterator.
     pub rciter: Rc<RefCell<I>>,

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -3,6 +3,7 @@
 ///
 /// See [`repeat_n()`](../fn.repeat_n.html) for more information.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[derive(Debug)]
 pub struct RepeatN<A> {
     elt: Option<A>,
     n: usize,

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 
 /// Common buffer object for the two tee halves
+#[derive(Debug)]
 struct TeeBuffer<A, I> {
     backlog: VecDeque<A>,
     iter: I,
@@ -16,6 +17,7 @@ struct TeeBuffer<A, I> {
 ///
 /// See [`.tee()`](../trait.Itertools.html#method.tee) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug)]
 pub struct Tee<I>
     where I: Iterator
 {

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -6,6 +6,7 @@ use std::iter::Fuse;
 ///
 /// See [`.tuples()`](../trait.Itertools.html#method.tuples) and
 /// [`Tuples::into_buffer()`](struct.Tuples.html#method.into_buffer).
+#[derive(Debug)]
 pub struct TupleBuffer<T>
     where T: TupleCollect
 {
@@ -116,6 +117,7 @@ impl<I, T> Tuples<I, T>
 /// See [`.tuple_windows()`](../trait.Itertools.html#method.tuple_windows) for more
 /// information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug)]
 pub struct TupleWindows<I, T>
     where I: Iterator<Item = T::Item>,
           T: TupleCollect

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -3,7 +3,7 @@ use super::size_hint;
 /// An iterator which iterates two other iterators simultaneously
 ///
 /// See [`.zip_eq()`](../trait.Itertools.html#method.zip_eq) for more information.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct ZipEq<I, J> {
     a: I,

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -12,7 +12,7 @@ use either_or_both::EitherOrBoth;
 /// This iterator is *fused*.
 ///
 /// See [`.zip_longest()`](../trait.Itertools.html#method.zip_longest) for more information.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct ZipLongest<T, U> {
     a: Fuse<T>,

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -1,7 +1,7 @@
 use super::size_hint;
 
 /// See [`multizip`](../fn.multizip.html) for more information.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Zip<T> {
     t: T,


### PR DESCRIPTION
This covers a part of https://github.com/bluss/rust-itertools/issues/32

I looked for all `struct`s and `enum`s and added `#[derive(Debug)]` where possible. I added a `Debug` impl for `KMerge`, `KMergeBy`, `MergeJoinBy` using `debug_fmt_fields`, printing all fields except function callable objects.