### PR TITLE
Introduce format_with_bookends

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -115,9 +115,9 @@ impl<'a, I> Format<'a, I>
 }
 
 macro_rules! impl_format {
-    ($($fmt_trait:ident)*) => {
+    ($fmt_struct:ident, $($fmt_trait:ident)*) => {
         $(
-            impl<'a, I> fmt::$fmt_trait for Format<'a, I>
+            impl<'a, I> fmt::$fmt_trait for $fmt_struct<'a, I>
                 where I: Iterator,
                       I::Item: fmt::$fmt_trait,
             {
@@ -129,8 +129,8 @@ macro_rules! impl_format {
     }
 }
 
-impl_format!{Display Debug
-             UpperExp LowerExp UpperHex LowerHex Octal Binary Pointer}
+impl_format!{Format,
+  Display Debug UpperExp LowerExp UpperHex LowerHex Octal Binary Pointer}
 
 impl<'a, I> FormatWithBookends<'a, I>
     where I: Iterator,
@@ -158,20 +158,5 @@ impl<'a, I> FormatWithBookends<'a, I>
     }
 }
 
-macro_rules! impl_format_with_bookends {
-    ($($fmt_trait:ident)*) => {
-        $(
-            impl<'a, I> fmt::$fmt_trait for FormatWithBookends<'a, I>
-                where I: Iterator,
-                      I::Item: fmt::$fmt_trait,
-            {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    self.format(f, fmt::$fmt_trait::fmt)
-                }
-            }
-        )*
-    }
-}
-
-impl_format_with_bookends!{Display Debug
-                           UpperExp LowerExp UpperHex LowerHex Octal Binary Pointer}
+impl_format!{FormatWithBookends,
+  Display Debug UpperExp LowerExp UpperHex LowerHex Octal Binary Pointer}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub mod structs {
     pub use combinations::Combinations;
     pub use cons_tuples_impl::ConsTuples;
     pub use exactly_one_err::ExactlyOneError;
-    pub use format::{Format, FormatWith};
+    pub use format::{Format, FormatWith, FormatWithBookends};
     #[cfg(feature = "use_std")]
     pub use groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use intersperse::Intersperse;
@@ -1498,6 +1498,14 @@ pub trait Itertools : Iterator {
         where Self: Sized,
     {
         format::new_format_default(self, sep)
+    }
+
+    /// Like `format` with prefix prepended and suffix append,
+    /// except returns the empty string if the input is empty.
+    fn format_with_bookends<'a>(self, prefix: &'a str, sep: &'a str, suffix: &'a str) -> FormatWithBookends<'a, Self>
+        where Self: Sized,
+    {
+        format::new_format_with_bookends(self, prefix, sep, suffix)
     }
 
     /// Format all iterator elements, separated by `sep`.

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -681,6 +681,31 @@ fn format() {
 }
 
 #[test]
+fn format_with_bookends() {
+    let data = [0, 1, 2, 3];
+    let ans1 = "[0, 1, 2, 3]";
+    let ans2 = "[0--1--2--3]";
+
+    let t1 = format!("{}", data.iter().format_with_bookends("[", ", ", "]"));
+    assert_eq!(t1, ans1);
+    let t2 = format!("{:?}", data.iter().format_with_bookends("[", "--", "]"));
+    assert_eq!(t2, ans2);
+
+    let dataf = [1.1, 2.71828, -22.];
+    let ans3 = "[1.10e0, 2.72e0, -2.20e1]";
+    let t3 = format!("{:.2e}", dataf.iter().format_with_bookends("[", ", ", "]"));
+    assert_eq!(t3, ans3);
+
+    let data: &[i8] = &[];
+    let ans = "";
+
+    let t1 = format!("{}", data.iter().format_with_bookends("[", ", ", "]"));
+    assert_eq!(t1, ans);
+    let t2 = format!("{:?}", data.iter().format_with_bookends("[", ", ", "]"));
+    assert_eq!(t2, ans);
+}
+
+#[test]
 fn while_some() {
     let ns = (1..10).map(|x| if x % 5 != 0 { Some(x) } else { None })
                     .while_some();


### PR DESCRIPTION
Like format, but with optional "bookends" if the iterator isn't empty.

Feedback very welcome.

Particularly it would be nice to dedup/DRY-up the similiarities with `Format`.