### PR TITLE
Cleanup unique implementation

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -743,3 +743,15 @@ fn unique_lazy_1(b: &mut test::Bencher) {
 
     b.iter(|| data.iter().unique().count())
 }
+
+#[bench]
+fn unique_lazy_2(b: &mut test::Bencher) {
+    let mut data = vec![0; 1024];
+    for (index, elt) in data.iter_mut().enumerate() {
+        *elt = index / 10;
+    }
+
+    let data = test::black_box(data);
+
+    b.iter(|| data.iter().unique().for_each(|_| ()))
+}

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -731,3 +731,15 @@ fn cartesian_product_nested_for(b: &mut test::Bencher)
         sum
     })
 }
+
+#[bench]
+fn unique_lazy_1(b: &mut test::Bencher) {
+    let mut data = vec![0; 1024];
+    for (index, elt) in data.iter_mut().enumerate() {
+        *elt = index / 10;
+    }
+
+    let data = test::black_box(data);
+
+    b.iter(|| data.iter().unique().count())
+}

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -91,7 +91,7 @@ impl<I> Iterator for Unique<I>
     }
 
     fn count(self) -> usize {
-        self.iter.count()
+        count_new_keys(self.iter.used, self.iter.iter)
     }
 }
 

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -75,7 +75,7 @@ impl<I, V, F> Iterator for UniqueBy<I, V, F>
 
 impl<I> Iterator for Unique<I>
     where I: Iterator,
-          I::Item: Eq + Hash
+          I::Item: Eq + Hash + Clone
 {
     type Item = I::Item;
 
@@ -98,13 +98,16 @@ impl<I> Iterator for Unique<I>
 /// See [`.unique()`](../trait.Itertools.html#method.unique) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct Unique<I: Iterator> {
+pub struct Unique<I: Iterator>
+    where I: Iterator,
+          I::Item: Eq + Hash + Clone,
+{
     iter: UniqueBy<I, I::Item, fn(&I::Item) -> I::Item>,
 }
 
 impl<I> fmt::Debug for Unique<I>
     where I: Iterator + fmt::Debug,
-          I::Item: Hash + Eq + fmt::Debug,
+          I::Item: Hash + Eq + Clone + fmt::Debug,
 {
     debug_fmt_fields!(Unique, iter);
 }


### PR DESCRIPTION
`.unique()` is just a special case of `.unique_by()` where the function applied to each key is `clone`. (Keys must be `Clone` already because of the Entry API usage.) Realizing this, quite a bit of duplicate/redundant code can be eliminated. This PR also adds benchmarks for `unique()`. 