### PR TITLE
MultiProductArray/iproduct_arr

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -713,6 +713,38 @@ fn multi_cartesian_product_fold(b: &mut test::Bencher)
 }
 
 #[bench]
+fn multi_cartesian_product_array_iterator(b: &mut test::Bencher)
+{
+    let xs = vec![0; 16];
+
+    b.iter(|| {
+        let mut sum = 0;
+        for x in iproduct_arr![&xs; 3] {
+            sum += x[0];
+            sum += x[1];
+            sum += x[2];
+        }
+        sum
+    })
+}
+
+#[bench]
+fn multi_cartesian_product_array_fold(b: &mut test::Bencher)
+{
+    let xs = vec![0; 16];
+
+    b.iter(|| {
+        let mut sum = 0;
+        iproduct_arr![&xs; 3].fold((), |(), x| {
+            sum += x[0];
+            sum += x[1];
+            sum += x[2];
+        });
+        sum
+    })
+}
+
+#[bench]
 fn cartesian_product_nested_for(b: &mut test::Bencher)
 {
     let xs = vec![0; 16];

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -2,144 +2,212 @@
 
 use size_hint;
 use Itertools;
+use std::marker::PhantomData;
 
 #[derive(Clone)]
 /// An iterator adaptor that iterates over the cartesian product of
 /// multiple iterators of type `I`.
 ///
-/// An iterator element type is `Vec<I>`.
+/// An iterator element type is `Vec<I::Item>`.
 ///
 /// See [`.multi_cartesian_product()`](../trait.Itertools.html#method.multi_cartesian_product)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct MultiProduct<I>(Vec<MultiProductIter<I>>)
-    where I: Iterator + Clone,
-          I::Item: Clone;
+pub struct MultiProduct<I>
+    where I: Iterator + Clone
+{
+    iters: Vec<MultiProductIter<I>>,
+    cur: Option<Vec<I::Item>>,
+}
+
+
+/// An iterator adaptor that iterates over the cartesian product of
+/// multiple iterators of type `I`.
+///
+/// An iterator element type is `[I::Item; N]`, where `N` is the number of
+/// sub-iterators.
+///
+/// Type `A` is a dummy array type, the length of which is used to determine the
+/// length of yielded items when iterating. The array item component of `A` is
+/// not used.
+///
+/// See [`iproduct_arr`](../macro.iproduct_arr.html) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct MultiProductArray<I, A>(MultiProduct<I>, PhantomData<A>)
+    where I: Iterator + Clone;
 
 /// Create a new cartesian product iterator over an arbitrary number
 /// of iterators of the same type.
 ///
 /// Iterator element is of type `Vec<H::Item::Item>`.
-pub fn multi_cartesian_product<H>(iters: H) -> MultiProduct<<H::Item as IntoIterator>::IntoIter>
+pub fn multi_cartesian_product<H>(iters: H)
+    -> MultiProduct<<H::Item as IntoIterator>::IntoIter>
     where H: Iterator,
           H::Item: IntoIterator,
           <H::Item as IntoIterator>::IntoIter: Clone,
-          <H::Item as IntoIterator>::Item: Clone
 {
-    MultiProduct(iters.map(|i| MultiProductIter::new(i.into_iter())).collect())
+    MultiProduct {
+        iters: iters.map(|iter| {
+            let iter = iter.into_iter();
+            MultiProductIter {
+                iter: iter.clone(),
+                iter_orig: iter
+            }
+        }).collect(),
+        cur: None
+    }
 }
 
 #[derive(Clone, Debug)]
 /// Holds the state of a single iterator within a MultiProduct.
 struct MultiProductIter<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
+    where I: Iterator + Clone
 {
-    cur: Option<I::Item>,
     iter: I,
     iter_orig: I,
 }
 
-/// Holds the current state during an iteration of a MultiProduct.
-#[derive(Debug)]
-enum MultiProductIterState {
-    StartOfIter,
-    MidIter { on_first_iter: bool },
-}
-
 impl<I> MultiProduct<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
+    where I: Iterator + Clone
 {
+    /// Converts this iterator into one which yields arrays instead of `Vec`s.
+    /// 
+    /// Type `A` is a dummy array type, the length of which is used to determine
+    /// the length of yielded items when iterating. If the number of
+    /// sub-iterators does not match the length of type `A`, it will `panic`.
+    /// 
+    /// The array item component of `A` is not used.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// let mut multi_prod_array = (0..3).map(|_| 4..6);
+    /// ```
+    /// 
+    /// In most instances, it is preferable to use the
+    /// [`iproduct_arr`](../macro.iproduct_arr.html).
+    pub fn array<A>(self) -> MultiProductArray<I, A>
+        where MultiProductArray<I, A>: AssertIterLength
+    {
+        let prod = MultiProductArray(self, PhantomData::<A>);
+        prod.assert_iter_length();
+        prod
+    }
+
+    /// Returns first item of each iterator as a `Vec`, or None if any iterator
+    /// is empty.
+    fn initial_iteration(
+        multi_iters: &mut [MultiProductIter<I>]
+    ) -> Option<Vec<I::Item>> {
+        let iter_count = multi_iters.len();
+
+        let initial: Vec<I::Item> = multi_iters.iter_mut()
+            .map(|multi_iter| multi_iter.iter.next())
+            .while_some()
+            .collect();
+
+        if initial.len() == iter_count {
+            Some(initial)
+        } else {
+            None
+        }
+    }
+
     /// Iterates the rightmost iterator, then recursively iterates iterators
     /// to the left if necessary.
     ///
-    /// Returns true if the iteration succeeded, else false.
+    /// Returns `Ok(())` if the iteration succeeded, else `Err(())`.
     fn iterate_last(
         multi_iters: &mut [MultiProductIter<I>],
-        mut state: MultiProductIterState
-    ) -> bool {
-        use self::MultiProductIterState::*;
+        curs: &mut [I::Item]
+    ) -> Result<(), ()> {
+        // If split fails, reached end of iterator list; all iterators finished.
+        let (last, rest) = try!(multi_iters.split_last_mut().ok_or(()));
 
-        if let Some((last, rest)) = multi_iters.split_last_mut() {
-            let on_first_iter = match state {
-                StartOfIter => {
-                    let on_first_iter = !last.in_progress();
-                    state = MidIter { on_first_iter: on_first_iter };
-                    on_first_iter
-                },
-                MidIter { on_first_iter } => on_first_iter
-            };
+        // Should be the same length as multi_iters
+        let (last_cur, rest_curs) = curs.split_last_mut().unwrap();
 
-            if !on_first_iter {
-                last.iterate();
-            }
-
-            if last.in_progress() {
-                true
-            } else if MultiProduct::iterate_last(rest, state) {
-                last.reset();
-                last.iterate();
-                // If iterator is None twice consecutively, then iterator is
-                // empty; whole product is empty.
-                last.in_progress()
-            } else {
-                false
-            }
+        *last_cur = if let Some(next) = last.iter.next() {
+            next
         } else {
-            // Reached end of iterator list. On initialisation, return true.
-            // At end of iteration (final iterator finishes), finish.
-            match state {
-                StartOfIter => false,
-                MidIter { on_first_iter } => on_first_iter
-            }
-        }
+            last.iter = last.iter_orig.clone();
+
+            // Propagate failures from further multi_iters
+            try!(Self::iterate_last(rest, rest_curs));
+
+            // If restarted iter returns None, it is empty, therefore whole
+            // product is empty; finish.
+            try!(last.iter.next().ok_or(()))
+        };
+
+        Ok(())
     }
 
-    /// Returns the unwrapped value of the next iteration.
-    fn curr_iterator(&self) -> Vec<I::Item> {
-        self.0.iter().map(|multi_iter| {
-            multi_iter.cur.clone().unwrap()
-        }).collect()
-    }
-
-    /// Returns true if iteration has started and has not yet finished; false
-    /// otherwise.
-    fn in_progress(&self) -> bool {
-        if let Some(last) = self.0.last() {
-            last.in_progress()
-        } else {
-            false
-        }
-    }
-}
-
-impl<I> MultiProductIter<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
-{
-    fn new(iter: I) -> Self {
-        MultiProductIter {
-            cur: None,
-            iter: iter.clone(),
-            iter_orig: iter
-        }
-    }
-
-    /// Iterate the managed iterator.
-    fn iterate(&mut self) {
-        self.cur = self.iter.next();
-    }
-
-    /// Reset the managed iterator.
-    fn reset(&mut self) {
-        self.iter = self.iter_orig.clone();
-    }
-
-    /// Returns true if the current iterator has been started and has not yet
-    /// finished; false otherwise.
     fn in_progress(&self) -> bool {
         self.cur.is_some()
+    }
+
+    fn advance(&mut self) {
+        if self.iters.len() == 0 {
+            return;
+        }
+
+        let mut finished = false;
+
+        match self.cur {
+            None => {
+                self.cur = Self::initial_iteration(&mut self.iters);
+            },
+            Some(ref mut cur) => {
+                finished = Self::iterate_last(&mut self.iters, cur) == Err(());
+            }
+        }
+
+        if finished {
+            self.cur = None;
+        }
+    }
+
+    fn _count(self) -> usize {
+        if self.iters.len() == 0 {
+            return 0;
+        }
+
+        if !self.in_progress() {
+            return self.iters.into_iter().fold(1, |acc, multi_iter| {
+                acc * multi_iter.iter.count()
+            });
+        }
+
+        self.iters.into_iter().fold(
+            0,
+            |acc, MultiProductIter { iter, iter_orig }| {
+                let total_count = iter_orig.count();
+                let cur_count = iter.count();
+                acc * total_count + cur_count
+            }
+        )
+    }
+
+    fn _size_hint(&self) -> (usize, Option<usize>) {
+        // Not ExactSizeIterator because size may be larger than usize
+        if self.iters.len() == 0 {
+            return (0, Some(0));
+        }
+
+        if !self.in_progress() {
+            return self.iters.iter().fold((1, Some(1)), |acc, multi_iter| {
+                size_hint::mul(acc, multi_iter.iter.size_hint())
+            });
+        }
+
+        self.iters.iter().fold(
+            (0, Some(0)),
+            |acc, &MultiProductIter { ref iter, ref iter_orig }| {
+                let cur_size = iter.size_hint();
+                let total_size = iter_orig.size_hint();
+                size_hint::add(size_hint::mul(acc, total_size), cur_size)
+            }
+        )
     }
 }
 
@@ -150,63 +218,27 @@ impl<I> Iterator for MultiProduct<I>
     type Item = Vec<I::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if MultiProduct::iterate_last(
-            &mut self.0,
-            MultiProductIterState::StartOfIter
-        ) {
-            Some(self.curr_iterator())
+        self.advance();
+
+        if let Some(ref cur) = self.cur {
+            Some(cur.clone())
         } else {
             None
         }
     }
 
     fn count(self) -> usize {
-        if self.0.len() == 0 {
-            return 0;
-        }
-
-        if !self.in_progress() {
-            return self.0.into_iter().fold(1, |acc, multi_iter| {
-                acc * multi_iter.iter.count()
-            });
-        }
-
-        self.0.into_iter().fold(
-            0,
-            |acc, MultiProductIter { iter, iter_orig, cur: _ }| {
-                let total_count = iter_orig.count();
-                let cur_count = iter.count();
-                acc * total_count + cur_count
-            }
-        )
+        self._count()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        // Not ExactSizeIterator because size may be larger than usize
-        if self.0.len() == 0 {
-            return (0, Some(0));
-        }
-
-        if !self.in_progress() {
-            return self.0.iter().fold((1, Some(1)), |acc, multi_iter| {
-                size_hint::mul(acc, multi_iter.iter.size_hint())
-            });
-        }
-
-        self.0.iter().fold(
-            (0, Some(0)),
-            |acc, &MultiProductIter { ref iter, ref iter_orig, cur: _ }| {
-                let cur_size = iter.size_hint();
-                let total_size = iter_orig.size_hint();
-                size_hint::add(size_hint::mul(acc, total_size), cur_size)
-            }
-        )
+        self._size_hint()
     }
 
     fn last(self) -> Option<Self::Item> {
-        let iter_count = self.0.len();
+        let iter_count = self.iters.len();
 
-        let lasts: Self::Item = self.0.into_iter()
+        let lasts: Vec<I::Item> = self.iters.into_iter()
             .map(|multi_iter| multi_iter.iter.last())
             .while_some()
             .collect();
@@ -217,4 +249,86 @@ impl<I> Iterator for MultiProduct<I>
             None
         }
     }
+}
+
+/// A trait to check that the number of iterators provided to a
+/// `MultiProductArray` is correct.
+pub trait AssertIterLength {
+    /// Asserts that the number of iterators matches the length of the Item
+    /// type.
+    fn assert_iter_length(&self);
+}
+
+macro_rules! multi_product_array_impl {
+    ($N:expr, $($M:expr,)*) => {
+        multi_product_array_impl!($($M,)*);
+
+        impl<I, _A> Iterator for MultiProductArray<I, [_A; $N]>
+            where I: Iterator + Clone,
+                  I::Item: Clone
+        {
+            type Item = [I::Item; $N];
+
+            fn next(&mut self) -> Option<Self::Item> {
+                (self.0).advance();
+
+                if let Some(ref cur) = (self.0).cur {
+                    let mut _cur_iter = cur.iter();
+                    Some([ $({
+                        $M; // Dummy macro expansion statement
+                        if let Some(c) = _cur_iter.next() {
+                            c.clone()
+                        } else {
+                            return None;
+                        }
+                    },)* ])
+                } else {
+                    None
+                }
+            }
+
+            fn count(self) -> usize {
+                (self.0)._count()
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                (self.0)._size_hint()
+            }
+
+            fn last(self) -> Option<Self::Item> {
+                let mut _lasts = (self.0).iters.into_iter()
+                    .map(|multi_iter| multi_iter.iter.last())
+                    .while_some();
+
+                Some([ $({
+                    $M; // Dummy macro expansion statement
+                    if let Some(last) = _lasts.next() {
+                        last
+                    } else {
+                        return None;
+                    }
+                },)* ])
+            }
+        }
+
+        impl<I, _A> AssertIterLength for MultiProductArray<I, [_A; $N]>
+            where I: Iterator + Clone
+        {
+            fn assert_iter_length(&self) {
+                let len = (self.0).iters.len();
+                if len != $N {
+                    panic!("MultiProductArray constructed with incorrect \
+                    number of iterators; iters={} arraylen={}", len, $N);
+                }
+            }
+        }
+    };
+    () => {};
+}
+
+multi_product_array_impl!{
+    32, 31, 30,
+    29, 28, 27, 26, 25, 24, 23, 22, 21, 20,
+    19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+    9,  8,  7,  6,  5,  4,  3,  2,  1,  0,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub mod structs {
         Update,
     };
     #[cfg(feature = "use_std")]
-    pub use adaptors::MultiProduct;
+    pub use adaptors::{MultiProduct, MultiProductArray};
     #[cfg(feature = "use_std")]
     pub use combinations::Combinations;
     pub use cons_tuples_impl::ConsTuples;
@@ -167,12 +167,19 @@ mod ziptuple;
 /// Iterator element type is like `(A, B, ..., E)` if formed
 /// from iterators `(I, J, ..., M)` with element types `I::Item = A`, `J::Item = B`, etc.
 ///
+/// Iterators are specified in a comma-separated list. A maxmimum of 8 iterators
+/// can be specified.
+///
 /// ```
 /// #[macro_use] extern crate itertools;
 /// # fn main() {
-/// // Iterate over the coordinates of a 4 x 4 x 4 grid
-/// // from (0, 0, 0), (0, 0, 1), .., (0, 1, 0), (0, 1, 1), .. etc until (3, 3, 3)
-/// for (i, j, k) in iproduct!(0..4, 0..4, 0..4) {
+/// let symbols = ['α', 'β'];
+/// let words = ["alpha", "bravo"];
+/// let numbers = [20, 30];
+///
+/// // Iterate over all combinations of elements from each iterator
+/// // from ('α', "alpha", 20), ('α', "alpha", 30), .. until ('β', "bravo", 30)
+/// for (symbol, word, num) in iproduct!(&symbols, &words, &numbers) {
 ///    // ..
 /// }
 /// # }
@@ -195,12 +202,73 @@ macro_rules! iproduct {
     ($I:expr) => (
         $crate::__std_iter::IntoIterator::into_iter($I)
     );
+    ($($I:expr,)+) => {
+        iproduct!($($I),+)
+    };
     ($I:expr, $J:expr) => (
         $crate::Itertools::cartesian_product(iproduct!($I), iproduct!($J))
     );
     ($I:expr, $J:expr, $($K:expr),+) => (
         iproduct!(@flatten iproduct!($I, $J), $($K,)+)
     );
+}
+
+#[macro_export]
+/// Creates an iterator over the "cartesian product" of iterators, where each
+/// iterator it of the same type.
+///
+/// Iterator element type is `[I::Item; N]`, where I is type of the
+/// sub-iterators, and `N` is the number of sub-iterators.
+///
+/// Iterators can be specified in a comma separated list. Or, if all iterators
+/// are identical and implement `Clone`, they can be specified with the
+/// shorthand `[iterator; N]` syntax, similar to `vec!` and array literals. A
+/// maximum of 32 iterators can be specified.
+///
+/// ```
+/// #[macro_use] extern crate itertools;
+/// # fn main() {
+/// // Iterate over the coordinates of a 3 x 4 x 5 grid
+/// // from [0, 0, 0], [0, 0, 1], .., [0, 1, 0], [0, 1, 1], .. etc until [2, 3, 4]
+/// for [i, j, k] in iproduct_arr![0..3, 0..4, 0..5] {
+///    // ..
+/// }
+///
+/// // Short-form when all iterators are identical
+/// for [i, j, k] in iproduct_arr![0..4; 3] {
+///    //..
+/// }
+/// # }
+/// ```
+///
+/// If the number of sub-iterators is not known at compile time, use
+/// [`.multi_cartesian_product()`](trait.Itertools.html#method.multi_cartesian_product)
+/// instead. If each sub-iterator is of a different type, use the
+/// [`iproduct`](macro.iproduct.html) macro.
+///
+/// **Note:** To enable the macros in this crate, use the `#[macro_use]`
+/// attribute when importing the crate:
+///
+/// ```
+/// #[macro_use] extern crate itertools;
+/// # fn main() { }
+/// ```
+macro_rules! iproduct_arr {
+    (@count $($I:expr, $(@$_I:tt)*)*) => {
+        0 $(+ $($_I)* 1 )*
+    };
+    (@prod $iter:expr, $N:expr) => {
+        $crate::Itertools::multi_cartesian_product($iter).array::<[(); $N]>()
+    };
+    ($($I:expr,)+) => {
+        iproduct_arr!($($I),+)
+    };
+    ($($I:expr),+) => {
+        iproduct_arr!(@prod vec![$($I),+].into_iter(), iproduct_arr!(@count $($I,)+))
+    };
+    ($I:expr; $N:expr) => {
+        iproduct_arr!(@prod $crate::repeat_n($I, $N), $N)
+    };
 }
 
 #[macro_export]

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -12,6 +12,7 @@ use std::default::Default;
 use quickcheck as qc;
 use std::ops::Range;
 use std::cmp::Ordering;
+use std::fmt::Debug;
 use itertools::Itertools;
 use itertools::{
     multizip,
@@ -321,6 +322,32 @@ fn size_range_u8(a: Iter<u8>) -> bool {
 }
  */
 
+fn _correct_product3<I, P>(a: ShiftRange, take_manual: usize, to_product: fn(a: ShiftRange) -> P, to_elt: fn(i: i32, j: i32, k: i32) -> I)
+    where I: PartialEq + Debug,
+            P: Iterator<Item=I>
+{
+    // Fix no. of iterators at 3
+    let a = ShiftRange { iter_count: 3, ..a };
+
+    // test correctness of Product through regular iteration (take)
+    // and through fold.
+    let mut iters = a.clone();
+    let i0 = iters.next().unwrap();
+    let i1r = &iters.next().unwrap();
+    let i2r = &iters.next().unwrap();
+    let answer: Vec<_> = i0.flat_map(move |ei0| i1r.clone().flat_map(move |ei1| i2r.clone().map(move |ei2| to_elt(ei0, ei1, ei2)))).collect();
+    let mut product = to_product(a.clone());
+    let mut actual = Vec::new();
+
+    actual.extend((&mut product).take(take_manual));
+    if actual.len() == take_manual {
+        product.fold((), |(), elt| actual.push(elt));
+    }
+    assert_eq!(answer, actual);
+
+    assert_eq!(answer.into_iter().last(), to_product(a).last());
+}
+
 macro_rules! quickcheck {
     // accept several property function definitions
     // The property functions can use pattern matching and `mut` as usual
@@ -357,50 +384,26 @@ quickcheck! {
     fn size_product3(a: Iter<u16>, b: Iter<u16>, c: Iter<u16>) -> bool {
         correct_size_hint(iproduct!(a, b, c))
     }
-
-    fn correct_cartesian_product3(a: Iter<u16>, b: Iter<u16>, c: Iter<u16>,
-                                  take_manual: usize) -> ()
-    {
-        // test correctness of iproduct through regular iteration (take)
-        // and through fold.
-        let ac = a.clone();
-        let br = &b.clone();
-        let cr = &c.clone();
-        let answer: Vec<_> = ac.flat_map(move |ea| br.clone().flat_map(move |eb| cr.clone().map(move |ec| (ea, eb, ec)))).collect();
-        let mut product_iter = iproduct!(a, b, c);
-        let mut actual = Vec::new();
-
-        actual.extend((&mut product_iter).take(take_manual));
-        if actual.len() == take_manual {
-            product_iter.fold((), |(), elt| actual.push(elt));
-        }
-        assert_eq!(answer, actual);
-    }
-
     fn size_multi_product(a: ShiftRange) -> bool {
         correct_size_hint(a.multi_cartesian_product())
     }
-    fn correct_multi_product3(a: ShiftRange, take_manual: usize) -> () {
-        // Fix no. of iterators at 3
-        let a = ShiftRange { iter_count: 3, ..a };
-
-        // test correctness of MultiProduct through regular iteration (take)
-        // and through fold.
-        let mut iters = a.clone();
-        let i0 = iters.next().unwrap();
-        let i1r = &iters.next().unwrap();
-        let i2r = &iters.next().unwrap();
-        let answer: Vec<_> = i0.flat_map(move |ei0| i1r.clone().flat_map(move |ei1| i2r.clone().map(move |ei2| vec![ei0, ei1, ei2]))).collect();
-        let mut multi_product = a.clone().multi_cartesian_product();
-        let mut actual = Vec::new();
-
-        actual.extend((&mut multi_product).take(take_manual));
-        if actual.len() == take_manual {
-            multi_product.fold((), |(), elt| actual.push(elt));
+    fn size_multi_product_arr(a: ShiftRange) -> bool {
+        match a.iter_count {
+            0 => correct_size_hint(iproduct_arr![a; 0]),
+            1 => correct_size_hint(iproduct_arr![a; 1]),
+            2 => correct_size_hint(iproduct_arr![a; 2]),
+            3 => correct_size_hint(iproduct_arr![a; 3]),
+            _ => panic!()
         }
-        assert_eq!(answer, actual);
-
-        assert_eq!(answer.into_iter().last(), a.clone().multi_cartesian_product().last());
+    }
+    fn correct_product3(a: ShiftRange, take_manual: usize) -> () {
+        _correct_product3(a, take_manual, |mut a| iproduct!(a.next().unwrap(), a.next().unwrap(), a.next().unwrap()), |i, j, k| (i, j, k))
+    }
+    fn correct_multi_product3(a: ShiftRange, take_manual: usize) -> () {
+        _correct_product3(a.clone(), take_manual, |a| a.multi_cartesian_product(), |i, j, k| vec![i, j, k])
+    }
+    fn correct_multi_product_arr3(a: ShiftRange, take_manual: usize) -> () {
+        _correct_product3(a, take_manual, |mut a| iproduct_arr![a.next().unwrap(), a.next().unwrap(), a.next().unwrap()], |i, j, k| [i, j, k])
     }
 
     fn size_step(a: Iter<i16, Exact>, s: usize) -> bool {


### PR DESCRIPTION
Fixes 264.

I've added a new macro, `iproduct_arr`, which can be called in the same way as `iproduct` (but only when all iterators are the same type) or using the `[iter; count]` format, as requested in the issue.

The macro uses a new underlying type, `MultiProductArray`, which is like a `MultiProduct` but yields arrays instead of vecs.

I did consider using something similar to the combination of `ConsTuples`+`Product` which `iproduct` uses, but found that utilising `MultiProduct` as a base was a better fit. The tradeoffs of this decision are as follows:

* A user can create their own `MultiProductArray` without using the macro, and in this case use a meta-iterator as the source, as long as the number of produced sub-iterators is known at compile-time. (e.g. `(0..3).map(|i| 0..i)`)
* The benchmark tests show that it is about 1.25x faster in the for-loop, but about 6.5x slower in the `.fold()` (and still many times faster than the vec-based `MultiProduct`). I haven't benched with types which allocate heap memory.

Creating a `MultiProductArray` manually requires the user to specify an array type parameter with length matching the number of sub-iterators. It uses a trait, implemented only on array types, to assert that this length is correct upon construction. The trait is "public-private", so that it cannot be implemented by users.

I've updated the documentation for `iproduct` and `multi_cartesian_product` to compare them with `iproduct_arr`.

While adding quickcheck tests, I refactored the main tests for `Product`, `MultiProduct` and `MultiProductArray` to use the same underlying function. `MultiProduct`'s test should be functionally identical to before, whilst `Product` now has slightly different input variables, and additionally tests `.last()`.

During development, I ended up doing a fairly significant refactor of `MultiProduct`. The original reason for this was a potential performance improvement; however I didn't realise that the improvement is not possible on rustc 1.12 (without further impl type restrictions). As a result, the current implementation would probably work without this refactor. So there are probably more changes for you to review than strictly necessary... but it does also introduce a ~5% speed increase for `MultiProduct` :)

Also, I added a match-arm to both `iproduct` and `iproduct_arr` to allow trailing commas.

As always, let me know if there are any API/syntax changes that you think should be made, plus any other issues you see with the aforementioned changes.