### PR TITLE
Derive Eq and PartialEq for FoldWhile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2095,7 +2095,7 @@ pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
 /// An enum used for controlling the execution of `.fold_while()`.
 ///
 /// See [`.fold_while()`](trait.Itertools.html#method.fold_while) for more information.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FoldWhile<T> {
     /// Continue folding with this value
     Continue(T),


### PR DESCRIPTION
This is useful for testing. (It's currently not possible to use `assert_eq!()` with `FoldWhile`.)