### PR TITLE
Bump MSRV to 1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 matrix:
   include:
-    - rust: 1.12.0
+    - rust: 1.13.0
       before_script:
         # rand 0.4.2 requires rust 1.15, and rand-0.3.22 requires rand-0.4  :/
         # manually hacking the lockfile due to the limitations of cargo#2773


### PR DESCRIPTION
Current libc is not compatible wit 1.12.0, so it's probably time for
us to bump the min version as well.