### PR TITLE
Add exactly_one function

### DIFF
--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -1,3 +1,5 @@
+use size_hint;
+
 /// Iterator returned for the error case of `IterTools::exactly_one()`
 /// This iterator yields exactly the same elements as the input iterator.
 ///
@@ -37,5 +39,16 @@ where
             .take()
             .or_else(|| self.first_two.1.take())
             .or_else(|| self.inner.next())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut additional_len = 0;
+        if self.first_two.0.is_some() {
+            additional_len += 1;
+        }
+        if self.first_two.1.is_some() {
+            additional_len += 1;
+        }
+        size_hint::add_scalar(self.inner.size_hint(), additional_len)
     }
 }

--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -1,0 +1,41 @@
+/// Iterator returned for the error case of `IterTools::exactly_one()`
+/// This iterator yields exactly the same elements as the input iterator.
+///
+/// During the execution of exactly_one the iterator must be mutated.  This wrapper
+/// effectively "restores" the state of the input iterator when it's handed back.
+///
+/// This is very similar to PutBackN except this iterator only supports 0-2 elements and does not
+/// use a `Vec`.
+#[derive(Debug, Clone)]
+pub struct ExactlyOneErr<T, I>
+where
+    I: Iterator<Item = T>,
+{
+    first_two: (Option<T>, Option<T>),
+    inner: I,
+}
+
+impl<T, I> ExactlyOneErr<T, I>
+where
+    I: Iterator<Item = T>,
+{
+    /// Creates a new `ExactlyOneErr` iterator.
+    pub fn new(first_two: (Option<T>, Option<T>), inner: I) -> Self {
+        Self { first_two, inner }
+    }
+}
+
+impl<T, I> Iterator for ExactlyOneErr<T, I>
+where
+    I: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.first_two
+            .0
+            .take()
+            .or_else(|| self.first_two.1.take())
+            .or_else(|| self.inner.next())
+    }
+}

--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -1,3 +1,5 @@
+use std::iter::ExactSizeIterator;
+
 use size_hint;
 
 /// Iterator returned for the error case of `IterTools::exactly_one()`
@@ -9,31 +11,31 @@ use size_hint;
 /// This is very similar to PutBackN except this iterator only supports 0-2 elements and does not
 /// use a `Vec`.
 #[derive(Debug, Clone)]
-pub struct ExactlyOneErr<T, I>
+pub struct ExactlyOneError<I>
 where
-    I: Iterator<Item = T>,
+    I: Iterator,
 {
-    first_two: (Option<T>, Option<T>),
+    first_two: (Option<I::Item>, Option<I::Item>),
     inner: I,
 }
 
-impl<T, I> ExactlyOneErr<T, I>
+impl<I> ExactlyOneError<I>
 where
-    I: Iterator<Item = T>,
+    I: Iterator,
 {
     /// Creates a new `ExactlyOneErr` iterator.
-    pub fn new(first_two: (Option<T>, Option<T>), inner: I) -> Self {
+    pub fn new(first_two: (Option<I::Item>, Option<I::Item>), inner: I) -> Self {
         Self { first_two, inner }
     }
 }
 
-impl<T, I> Iterator for ExactlyOneErr<T, I>
+impl<I> Iterator for ExactlyOneError<I>
 where
-    I: Iterator<Item = T>,
+    I: Iterator,
 {
-    type Item = T;
+    type Item = I::Item;
 
-    fn next(&mut self) -> Option<T> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.first_two
             .0
             .take()
@@ -52,3 +54,5 @@ where
         size_hint::add_scalar(self.inner.size_hint(), additional_len)
     }
 }
+
+impl<I> ExactSizeIterator for ExactlyOneError<I> where I: ExactSizeIterator {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub mod structs {
     #[cfg(feature = "use_std")]
     pub use combinations::Combinations;
     pub use cons_tuples_impl::ConsTuples;
-    pub use exactly_one_err::ExactlyOneErr;
+    pub use exactly_one_err::ExactlyOneError;
     pub use format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
     pub use groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
@@ -2003,7 +2003,7 @@ pub trait Itertools : Iterator {
     /// assert!((0..10).filter(|&x| x > 1 && x < 5).exactly_one().unwrap_err().eq(2..5));
     /// assert!((0..10).filter(|&x| false).exactly_one().unwrap_err().eq(0..0));
     /// ```
-    fn exactly_one(mut self) -> Result<Self::Item, ExactlyOneErr<Self::Item, Self>>
+    fn exactly_one(mut self) -> Result<Self::Item, ExactlyOneError<Self>>
     where
         Self: Sized,
     {
@@ -2011,14 +2011,14 @@ pub trait Itertools : Iterator {
             Some(first) => {
                 match self.next() {
                     Some(second) => {
-                        Err(ExactlyOneErr::new((Some(first), Some(second)), self))
+                        Err(ExactlyOneError::new((Some(first), Some(second)), self))
                     }
                     None => {
                         Ok(first)
                     }
                 }
             }
-            None => Err(ExactlyOneErr::new((None, None), self)),
+            None => Err(ExactlyOneError::new((None, None), self)),
         }
     }
 }


### PR DESCRIPTION
Adds a small function I found uses for personally.  Can't be added to the core library because in the error case it allocates a vec and stores data in it.