### PR TITLE
Remove .flatten() and flatten()

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -10,7 +10,7 @@ pub use self::multi_product::*;
 
 use std::fmt;
 use std::mem::replace;
-use std::iter::{Flatten, Fuse, Peekable, FromIterator};
+use std::iter::{Fuse, Peekable, FromIterator};
 use std::marker::PhantomData;
 use size_hint;
 
@@ -1033,31 +1033,6 @@ impl_tuple_combination!(Tuple2Combination Tuple1Combination ; A, A, A ; a);
 impl_tuple_combination!(Tuple3Combination Tuple2Combination ; A, A, A, A ; a b);
 impl_tuple_combination!(Tuple4Combination Tuple3Combination ; A, A, A, A, A; a b c);
 
-
-/// Flatten an iterable of iterables into a single combined sequence of all
-/// the elements in the iterables.
-///
-/// This is more or less equivalent to `.flat_map` with an identity
-/// function.
-///
-/// This is an `IntoIterator`-enabled version of the [`.flatten()`][1] adaptor.
-///
-/// [1]: trait.Itertools.html#method.flatten
-///
-/// ```
-/// use itertools::flatten;
-///
-/// let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
-///
-/// itertools::assert_equal(flatten(&data),
-///                         &[1, 2, 3, 4, 5, 6]);
-/// ```
-pub fn flatten<I>(iterable: I) -> Flatten<I::IntoIter>
-    where I: IntoIterator,
-          I::Item: IntoIterator,
-{
-    iterable.into_iter().flatten()
-}
 
 /// An iterator adapter to apply a transformation within a nested `Result`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,6 @@ pub mod structs {
     pub use ziptuple::Zip;
 }
 pub use structs::*;
-pub use adaptors::flatten;
 pub use concat_impl::concat;
 pub use cons_tuples_impl::cons_tuples;
 pub use diff::diff_with;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,6 @@ pub mod structs {
         WhileSome,
         Coalesce,
         TupleCombinations,
-        Flatten,
         Positions,
         Update,
     };
@@ -1106,29 +1105,6 @@ pub trait Itertools : Iterator {
               F: FnMut(usize) -> Self::Item
     {
         pad_tail::pad_using(self, min, f)
-    }
-
-    /// Flatten an iterator of iterables into a single combined sequence of all
-    /// the elements in the iterables.
-    ///
-    /// This is more or less equivalent to `.flat_map` with an identity
-    /// function.
-    ///
-    /// See also the [`flatten`](fn.flatten.html) function.
-    ///
-    /// ```ignore
-    /// use itertools::Itertools;
-    ///
-    /// let data = vec![vec![1, 2, 3], vec![4, 5, 6]];
-    /// let flattened = data.iter().flatten();
-    ///
-    /// itertools::assert_equal(flattened, &[1, 2, 3, 4, 5, 6]);
-    /// ```
-    fn flatten(self) -> Flatten<Self, <Self::Item as IntoIterator>::IntoIter>
-        where Self: Sized,
-              Self::Item: IntoIterator
-    {
-        adaptors::flatten(self)
     }
 
     /// Return an iterator adaptor that wraps each element in a `Position` to

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -17,7 +17,6 @@ use itertools::{
     multizip,
     EitherOrBoth,
 };
-use itertools::flatten;
 use itertools::free::{
     cloned,
     enumerate,
@@ -602,16 +601,6 @@ quickcheck! {
             inter = !inter;
         }
         true
-    }
-
-    fn equal_flatten(a: Vec<Option<i32>>) -> bool {
-        itertools::equal(flatten(&a),
-                         a.iter().filter_map(|x| x.as_ref()))
-    }
-
-    fn equal_flatten_vec(a: Vec<Vec<u8>>) -> bool {
-        itertools::equal(flatten(&a),
-                         a.iter().flat_map(|x| x))
     }
 
     fn equal_combinations_2(a: Vec<u8>) -> bool {

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -9,7 +9,6 @@
 
 use core::iter;
 
-use it::flatten;
 use it::Itertools;
 use it::interleave;
 use it::multizip;
@@ -234,19 +233,6 @@ fn part() {
     let i = it::partition(&mut data, |elt| *elt % 3 == 0);
     assert_eq!(i, 3);
     assert_eq!(data, [9, 6, 3, 4, 5, 2, 7, 8, 1]);
-}
-
-#[test]
-fn flatten_clone() {
-    let data = &[
-        &[1,2,3],
-        &[4,5,6]
-    ];
-    let flattened1 = flatten(data.into_iter().cloned());
-    let flattened2 = flattened1.clone();
-
-    it::assert_equal(flattened1, &[1,2,3,4,5,6]);
-    it::assert_equal(flattened2, &[1,2,3,4,5,6]);
 }
 
 #[test]

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -2,7 +2,6 @@
 #[macro_use] extern crate itertools as it;
 extern crate permutohedron;
 
-use it::flatten;
 use it::Itertools;
 use it::multizip;
 use it::multipeek;
@@ -536,23 +535,6 @@ fn concat_empty() {
 fn concat_non_empty() {
     let data = vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]];
     assert_eq!(data.into_iter().concat(), vec![1,2,3,4,5,6,7,8,9])
-}
-
-#[test]
-fn flatten_iter() {
-    let data = vec![vec![1,2,3], vec![4,5], vec![], vec![6]];
-    it::assert_equal(flatten(data), vec![1,2,3,4,5,6]);
-}
-
-#[test]
-fn flatten_fold() {
-    let xs = [0, 1, 1, 1, 2, 1, 3, 3];
-    let ch = xs.iter().chunks(3);
-    let mut iter = flatten(&ch);
-    iter.next();
-    let mut xs_d = Vec::new();
-    iter.fold((), |(), &elt| xs_d.push(elt));
-    assert_eq!(&xs_d[..], &xs[1..]);
 }
 
 #[test]


### PR DESCRIPTION
Please use them from std in Rust 1.28 or later

Fixes #262 