### PR TITLE
Deprecate methods replaced with versions in std

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -409,6 +409,7 @@ impl<B, F, I> Iterator for Batching<I, F>
 /// See [`.step()`](../trait.Itertools.html#method.step) for more information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[deprecated(note="Use std .step_by() instead", since="0.8")]
 pub struct Step<I> {
     iter: Fuse<I>,
     skip: usize,
@@ -417,6 +418,7 @@ pub struct Step<I> {
 /// Create a `Step` iterator.
 ///
 /// **Panics** if the step is 0.
+#[allow(deprecated)]
 pub fn step<I>(iter: I, step: usize) -> Step<I>
     where I: Iterator
 {
@@ -427,6 +429,7 @@ pub fn step<I>(iter: I, step: usize) -> Step<I>
     }
 }
 
+#[allow(deprecated)]
 impl<I> Iterator for Step<I>
     where I: Iterator
 {
@@ -454,6 +457,7 @@ impl<I> Iterator for Step<I>
 }
 
 // known size
+#[allow(deprecated)]
 impl<I> ExactSizeIterator for Step<I>
     where I: ExactSizeIterator
 {}

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -407,9 +407,10 @@ impl<B, F, I> Iterator for Batching<I, F>
 /// then skipping forward *n-1* elements.
 ///
 /// See [`.step()`](../trait.Itertools.html#method.step) for more information.
+#[deprecated(note="Use std .step_by() instead", since="0.8")]
+#[allow(deprecated)]
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[deprecated(note="Use std .step_by() instead", since="0.8")]
 pub struct Step<I> {
     iter: Fuse<I>,
     skip: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub mod structs {
     #[cfg(feature = "use_std")]
     pub use rciter_impl::RcIter;
     pub use repeatn::RepeatN;
+    #[allow(deprecated)]
     pub use sources::{RepeatCall, Unfold, Iterate};
     #[cfg(feature = "use_std")]
     pub use tee::Tee;
@@ -116,6 +117,7 @@ pub use minmax::MinMaxResult;
 pub use peeking_take_while::PeekingNext;
 pub use process_results_impl::process_results;
 pub use repeatn::repeat_n;
+#[allow(deprecated)]
 pub use sources::{repeat_call, unfold, iterate};
 pub use with_position::Position;
 pub use ziptuple::multizip;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1742,6 +1742,7 @@ pub trait Itertools : Iterator {
     /// The big difference between the computations of `result2` and `result3` is that while
     /// `fold()` called the provided closure for every item of the callee iterator,
     /// `fold_while()` actually stopped iterating as soon as it encountered `Fold::Done(_)`.
+    #[deprecated(note="Use .try_fold() instead", since="0.8")]
     fn fold_while<B, F>(&mut self, init: B, mut f: F) -> FoldWhile<B>
         where Self: Sized,
               F: FnMut(B, Self::Item) -> FoldWhile<B>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,6 @@ pub mod structs {
         Product,
         PutBack,
         Batching,
-        Step,
         MapResults,
         Merge,
         MergeBy,
@@ -72,6 +71,8 @@ pub mod structs {
         Positions,
         Update,
     };
+    #[allow(deprecated)]
+    pub use adaptors::Step;
     #[cfg(feature = "use_std")]
     pub use adaptors::MultiProduct;
     #[cfg(feature = "use_std")]
@@ -106,6 +107,7 @@ pub mod structs {
     pub use zip_longest::ZipLongest;
     pub use ziptuple::Zip;
 }
+#[allow(deprecated)]
 pub use structs::*;
 pub use concat_impl::concat;
 pub use cons_tuples_impl::cons_tuples;
@@ -630,6 +632,8 @@ pub trait Itertools : Iterator {
     /// let it = (0..8).step(3);
     /// itertools::assert_equal(it, vec![0, 3, 6]);
     /// ```
+    #[deprecated(note="Use std .step_by() instead", since="0.8")]
+    #[allow(deprecated)]
     fn step(self, n: usize) -> Step<Self>
         where Self: Sized
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1338,11 +1338,12 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal(rx.iter(), vec![1, 3, 5, 7, 9]);
     /// ```
-    fn foreach<F>(self, mut f: F)
+    #[deprecated(note="Use .for_each() instead", since="0.8")]
+    fn foreach<F>(self, f: F)
         where F: FnMut(Self::Item),
               Self: Sized,
     {
-        self.fold((), move |(), element| f(element))
+        self.for_each(f)
     }
 
     /// Combine all an iterator's elements into one element by using `Extend`.

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,10 +1,12 @@
 //! Iterators that are sources (produce elements from parameters,
 //! not from another iterator).
+#![allow(deprecated)]
 
 use std::fmt;
 use std::mem;
 
 /// See [`repeat_call`](../fn.repeat_call.html) for more information.
+#[deprecated(note="Use std repeat_with() instead", since="0.8")]
 pub struct RepeatCall<F> {
     f: F,
 }
@@ -36,6 +38,7 @@ impl<F> fmt::Debug for RepeatCall<F>
 ///     vec![1, 1, 1, 1, 1]
 /// );
 /// ```
+#[deprecated(note="Use std repeat_with() instead", since="0.8")]
 pub fn repeat_call<F, A>(function: F) -> RepeatCall<F>
     where F: FnMut() -> A
 {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -405,6 +405,7 @@ quickcheck! {
         assert_eq!(answer.into_iter().last(), a.clone().multi_cartesian_product().last());
     }
 
+    #[allow(deprecated)]
     fn size_step(a: Iter<i16, Exact>, s: usize) -> bool {
         let mut s = s;
         if s == 0 {
@@ -414,6 +415,8 @@ quickcheck! {
         correct_size_hint(filt.step(s)) &&
             exact_size(a.step(s))
     }
+
+    #[allow(deprecated)]
     fn equal_step(a: Iter<i16>, s: usize) -> bool {
         let mut s = s;
         if s == 0 {
@@ -426,6 +429,8 @@ quickcheck! {
             keep
         }))
     }
+
+    #[allow(deprecated)]
     fn equal_step_vec(a: Vec<i16>, s: usize) -> bool {
         let mut s = s;
         if s == 0 {
@@ -980,6 +985,7 @@ quickcheck! {
 }
 
 quickcheck! {
+    #[allow(deprecated)]
     fn tree_fold1_f64(mut a: Vec<f64>) -> TestResult {
         fn collapse_adjacent<F>(x: Vec<f64>, mut f: F) -> Vec<f64>
             where F: FnMut(f64, f64) -> f64

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -159,6 +159,7 @@ fn test_put_back() {
     it::assert_equal(pb, xs.iter().cloned());
 }
 
+#[allow(deprecated)]
 #[test]
 fn step() {
     it::assert_equal((0..10).step(1), 0..10);
@@ -166,6 +167,7 @@ fn step() {
     it::assert_equal((0..10).step(10), 0..1);
 }
 
+#[allow(deprecated)]
 #[test]
 fn merge() {
     it::assert_equal((0..10).step(2).merge((1..10).step(2)), 0..10);

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -113,6 +113,7 @@ fn test_interleave() {
     it::assert_equal(it, rs.iter());
 }
 
+#[allow(deprecated)]
 #[test]
 fn foreach() {
     let xs = [1i32, 2, 3];

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -220,6 +220,7 @@ fn merge_by_btree() {
     it::assert_equal(results, expected.into_iter());
 }
 
+#[allow(deprecated)]
 #[test]
 fn kmerge() {
     let its = (0..4).map(|s| (s..10).step(4));
@@ -227,6 +228,7 @@ fn kmerge() {
     it::assert_equal(its.kmerge(), 0..10);
 }
 
+#[allow(deprecated)]
 #[test]
 fn kmerge_2() {
     let its = vec![3, 2, 1, 0].into_iter().map(|s| (s..10).step(4));

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -165,6 +165,7 @@ fn test_rciter() {
     assert_eq!(z.next(), Some((0, 1)));
 }
 
+#[allow(deprecated)]
 #[test]
 fn trait_pointers() {
     struct ByRef<'r, I: ?Sized>(&'r mut I) where I: 'r;

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -684,6 +684,7 @@ fn while_some() {
     it::assert_equal(ns, vec![1, 2, 3, 4]);
 }
 
+#[allow(deprecated)]
 #[test]
 fn fold_while() {
     let mut iterations = 0;


### PR DESCRIPTION
Deprecate methods and functions that now have a corresponding version in std. Note that direct conflicts like `flatten` have already been removed instead. These "renames" we can keep deprecated until the next version after this is released.

There's a mystery stray deprecation warning in the crate's own compilation, and it doesn't have a location or file/line information. We haven't gotten quite to the bottom with that, yet. I can see it's not the glob imports inside `src/lib.rs`, at least.

```
warning: use of deprecated item 'adaptors::Step': Use std .step_by() instead
```

Cc #223 