### PR TITLE
Use assert_ne now that the minver is higher

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1690,10 +1690,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!((0..10).tree_fold1(|x, y| x + y),
     ///     (0..10).fold1(|x, y| x + y));
     /// // ...but not for non-associative ones
-    /// assert!((0..10).tree_fold1(|x, y| x - y)
-    ///     != (0..10).fold1(|x, y| x - y));
+    /// assert_ne!((0..10).tree_fold1(|x, y| x - y),
+    ///     (0..10).fold1(|x, y| x - y));
     /// ```
-    // FIXME: If minver changes to >= 1.13, use `assert_ne!` in the doctest.
     fn tree_fold1<F>(mut self, mut f: F) -> Option<Self::Item>
         where F: FnMut(Self::Item, Self::Item) -> Self::Item,
               Self: Sized,


### PR DESCRIPTION
I saw that itertools 0.8.0 is now on rust 1.24, so I think this is ok now?

(Not worth a point release, but I think still good to do.)